### PR TITLE
Loose the IP when going to standby

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 }
 
 func (c Config) LeaseTime() time.Duration {
-	return 3 * c.KeepAliveInterval
+	return 5 * c.KeepAliveInterval
 }
 
 func Build() (Config, error) {

--- a/ip/network.go
+++ b/ip/network.go
@@ -20,11 +20,10 @@ func (m *manager) setActivated(ctx context.Context, _ *fsm.Event) {
 func (m *manager) setStandBy(ctx context.Context, _ *fsm.Event) {
 	log := logger.Get(ctx)
 	log.Info("New state: STANDBY")
-	// Here we don't want to do anything.
-	// - if we came from a success state, we should keep the IP but not advertise it
-	//   we keep the IP to prevent broken connections. We still want to respond to this
-	//   IP even if another host is master.
-	// - If we came from failing state connections were already broken, no need to add the IP back.
+	err := m.networkInterface.RemoveIP(m.ip.IP)
+	if err != nil {
+		log.WithError(err).Error("Fail to de-activate IP")
+	}
 }
 
 func (m *manager) setFailing(ctx context.Context, _ *fsm.Event) {

--- a/ip/network_test.go
+++ b/ip/network_test.go
@@ -40,11 +40,13 @@ func TestSetStandBy(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		networkMock := networkmock.NewMockNetworkInterface(ctrl)
 		ip := models.IP{
 			IP: "10.0.0.1/32",
 			ID: "test-1234",
 		}
+
+		networkMock := networkmock.NewMockNetworkInterface(ctrl)
+		networkMock.EXPECT().RemoveIP(ip.IP).Return(nil)
 
 		manager := &manager{
 			networkInterface: networkMock,

--- a/locker/etcd_locker.go
+++ b/locker/etcd_locker.go
@@ -48,7 +48,10 @@ func (l *etcdLocker) Refresh(ctx context.Context) error {
 	// The goal of this transaction is to create the key with our leaseID only if this key does not exist
 	// We use a transaction to make sure that concurrent tries wont interfere with each others.
 
-	_, err := l.kvEtcd.Txn(ctx).
+	transactionCtx, cancel := context.WithTimeout(ctx, l.config.KeepAliveInterval)
+	defer cancel()
+
+	_, err := l.kvEtcd.Txn(transactionCtx).
 		// If the key does not exists (createRevision == 0)
 		If(clientv3.Compare(clientv3.CreateRevision(l.key), "=", 0)).
 		// Create it with our leaseID

--- a/locker/etcd_locker_test.go
+++ b/locker/etcd_locker_test.go
@@ -30,14 +30,14 @@ func TestRefresh(t *testing.T) {
 			Name:           "When we cannot get the lease",
 			InitialLeaseID: 0,
 			ExpectedLease: func(mock *etcdmock.MockLease) {
-				mock.EXPECT().Grant(gomock.Any(), int64(9)).Return(nil, errors.New("NOP"))
+				mock.EXPECT().Grant(gomock.Any(), int64(15)).Return(nil, errors.New("NOP"))
 			},
 			ExpectedError: "NOP",
 		}, {
 			Name:           "When the transaction fails and no lease were configured",
 			InitialLeaseID: 0,
 			ExpectedLease: func(mock *etcdmock.MockLease) {
-				mock.EXPECT().Grant(gomock.Any(), int64(9)).Return(&clientv3.LeaseGrantResponse{
+				mock.EXPECT().Grant(gomock.Any(), int64(15)).Return(&clientv3.LeaseGrantResponse{
 					ID: 12,
 				}, nil)
 			},
@@ -56,7 +56,7 @@ func TestRefresh(t *testing.T) {
 			InitialLeaseID:   0,
 			LastLeaseRefresh: time.Now(),
 			ExpectedLease: func(mock *etcdmock.MockLease) {
-				mock.EXPECT().Grant(gomock.Any(), int64(9)).Return(&clientv3.LeaseGrantResponse{
+				mock.EXPECT().Grant(gomock.Any(), int64(15)).Return(&clientv3.LeaseGrantResponse{
 					ID: 12,
 				}, nil)
 			},
@@ -75,7 +75,7 @@ func TestRefresh(t *testing.T) {
 			InitialLeaseID:   0,
 			LastLeaseRefresh: time.Now().Add(-1 * time.Hour),
 			ExpectedLease: func(mock *etcdmock.MockLease) {
-				mock.EXPECT().Grant(gomock.Any(), int64(9)).Return(&clientv3.LeaseGrantResponse{
+				mock.EXPECT().Grant(gomock.Any(), int64(15)).Return(&clientv3.LeaseGrantResponse{
 					ID: 12,
 				}, nil)
 			},
@@ -93,7 +93,7 @@ func TestRefresh(t *testing.T) {
 			Name:           "When keepalive fail",
 			InitialLeaseID: 0,
 			ExpectedLease: func(mock *etcdmock.MockLease) {
-				mock.EXPECT().Grant(gomock.Any(), int64(9)).Return(&clientv3.LeaseGrantResponse{
+				mock.EXPECT().Grant(gomock.Any(), int64(15)).Return(&clientv3.LeaseGrantResponse{
 					ID: 12,
 				}, nil)
 
@@ -112,7 +112,7 @@ func TestRefresh(t *testing.T) {
 			Name:           "When everything succeed",
 			InitialLeaseID: 0,
 			ExpectedLease: func(mock *etcdmock.MockLease) {
-				mock.EXPECT().Grant(gomock.Any(), int64(9)).Return(&clientv3.LeaseGrantResponse{
+				mock.EXPECT().Grant(gomock.Any(), int64(15)).Return(&clientv3.LeaseGrantResponse{
 					ID: 12,
 				}, nil)
 


### PR DESCRIPTION
Fix #62

This commit also does the following:
- Add a timeout for etcd locker transactions (the timeout is now the KeepAliveDuration)
- Change the LeaseTime to 5 * KeepAliveDuration (was 3 * KeepAliveDuration)