### PR TITLE
Add KeepAliveRetry in configuration defining how many times the lock will try to be refreshed before being in a faulty state

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Password                string        `envconfig:"PASSWORD"`
 	Port                    int           `envconfig:"PORT" default:"1313"`
 	KeepAliveInterval       time.Duration `envconfig:"KEEPALIVE_INTERVAL" default:"3s"`
+	KeepAliveRetry          int           `envconfig:"KEEPALIVE_RETRY" default:"5"`
 	HealthcheckInterval     time.Duration `envconfig:"HEALTH_CHECK_INTERVAL" default:"5s"`
 	HealthcheckTimeout      time.Duration `envconfig:"HEALTH_CHECK_TIMEOUT" default:"5s"`
 	ARPGratuitousInterval   time.Duration `envconfig:"ARP_GRATUITOUS_INTERVAL" default:"1s"`

--- a/ip/event_manager.go
+++ b/ip/event_manager.go
@@ -166,7 +166,7 @@ func (m *manager) singleEtcdRun(ctx context.Context) {
 	if err != nil {
 		m.keepaliveRetry++
 		log.WithError(err).Info("Fail to refresh lock (retry)")
-		if m.keepaliveRetry == m.config.KeepAliveRetry {
+		if m.keepaliveRetry > m.config.KeepAliveRetry {
 			log.WithError(err).Error("Fail to refresh lock")
 			m.sendEvent(FaultEvent)
 		}

--- a/ip/event_manager.go
+++ b/ip/event_manager.go
@@ -164,15 +164,22 @@ func (m *manager) singleEtcdRun(ctx context.Context) {
 	log := logger.Get(ctx)
 	err := m.locker.Refresh(ctx)
 	if err != nil {
-		log.WithError(err).Error("Fail to refresh lock")
-		m.sendEvent(FaultEvent)
+		m.keepaliveRetry++
+		log.WithError(err).Info("Fail to refresh lock (retry)")
+		if m.keepaliveRetry == m.config.KeepAliveRetry {
+			log.WithError(err).Error("Fail to refresh lock")
+			m.sendEvent(FaultEvent)
+		}
 		return
 	}
+	m.keepaliveRetry = 0
 
 	isMaster, err := m.locker.IsMaster(ctx)
 	if err != nil {
 		log.WithError(err).Error("Fail to check lock")
-		m.sendEvent(FaultEvent)
+		// Fault event should only be handled in the Refresh operation where the
+		// retry loop is present
+		return
 	} else {
 		if isMaster {
 			m.sendEvent(ElectedEvent)

--- a/ip/manager.go
+++ b/ip/manager.go
@@ -37,6 +37,7 @@ type manager struct {
 	checker          healthcheck.Checker
 	config           config.Config
 	eventChan        chan string
+	keepaliveRetry   int
 	failingCount     int
 	stopped          bool
 }

--- a/locker/etcd_locker.go
+++ b/locker/etcd_locker.go
@@ -71,7 +71,7 @@ func (l *etcdLocker) Refresh(ctx context.Context) error {
 			l.leaseID = 0
 			return errors.Wrapf(err, "fail to refresh lock: probably expired (leaseID = %v)", oldLeaseID)
 		} else {
-			// We got an error. This is probably not relaterd to an expired lease. Do not reset it
+			// We got an error. This is probably not related to an expired lease. Do not reset it
 			return errors.Wrapf(err, "fail to refresh lock")
 		}
 	}


### PR DESCRIPTION
Fixes #73