### PR TITLE
Only send 3 gratuitous ARP packets after switching to ACTIVATED state

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,28 +1,55 @@
 package config
 
 import (
+	"math/rand"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
 )
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 type Config struct {
-	Interface               string        `envconfig:"INTERFACE"`
-	Hostname                string        `envconfig:"HOSTNAME"`
-	User                    string        `envconfig:"USER"`
-	Password                string        `envconfig:"PASSWORD"`
-	Port                    int           `envconfig:"PORT" default:"1313"`
-	KeepAliveInterval       time.Duration `envconfig:"KEEPALIVE_INTERVAL" default:"3s"`
-	KeepAliveRetry          int           `envconfig:"KEEPALIVE_RETRY" default:"5"`
-	HealthcheckInterval     time.Duration `envconfig:"HEALTH_CHECK_INTERVAL" default:"5s"`
-	HealthcheckTimeout      time.Duration `envconfig:"HEALTH_CHECK_TIMEOUT" default:"5s"`
-	ARPGratuitousInterval   time.Duration `envconfig:"ARP_GRATUITOUS_INTERVAL" default:"1s"`
-	FailCountBeforeFailover int           `envconfig:"FAIL_COUNT_BEFORE_FAILOVER" default:"3"`
+	Interface             string        `envconfig:"INTERFACE"`
+	Hostname              string        `envconfig:"HOSTNAME"`
+	User                  string        `envconfig:"USER"`
+	Password              string        `envconfig:"PASSWORD"`
+	Port                  int           `envconfig:"PORT" default:"1313"`
+	KeepAliveInterval     time.Duration `envconfig:"KEEPALIVE_INTERVAL" default:"3s"`
+	KeepAliveRetry        int           `envconfig:"KEEPALIVE_RETRY" default:"5"`
+	HealthcheckInterval   time.Duration `envconfig:"HEALTH_CHECK_INTERVAL" default:"5s"`
+	HealthcheckTimeout    time.Duration `envconfig:"HEALTH_CHECK_TIMEOUT" default:"5s"`
+	ARPGratuitousInterval time.Duration `envconfig:"ARP_GRATUITOUS_INTERVAL" default:"1s"`
+	// Number of gratuitous ARP (GARP) packets sent when the state becomes 'ACTIVATED'
+	ARPGratuitousCount      int `envconfig:"ARP_GRATUITOUS_COUNT" default:"3"`
+	FailCountBeforeFailover int `envconfig:"FAIL_COUNT_BEFORE_FAILOVER" default:"3"`
 }
 
 func (c Config) LeaseTime() time.Duration {
 	return 5 * c.KeepAliveInterval
+}
+
+type Delta float64
+
+// DefaultDelta is the default value to use with PlusMinusDelta
+const DefaultDelta Delta = 0.25
+
+// PlusMinusDelta returns a number [value - value * delta ≤ value ≤ value + value * delta]
+func PlusMinusDelta(value float64, delta Delta) float64 {
+	lower := float64(value) * (1.0 - float64(delta))
+	higher := float64(value) * (1.0 + float64(delta))
+	diff := higher - lower
+	rate := rand.Float64()
+	return lower + rate*diff
+}
+
+// PlusMinusDeltaDuration is a helper to manipulate time.Duration with PlusMinusDelta
+func PlusMinusDeltaDuration(value time.Duration, delta Delta) time.Duration {
+	res := PlusMinusDelta(float64(value), delta)
+	return time.Duration(int64(res))
 }
 
 func Build() (Config, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -32,24 +32,10 @@ func (c Config) LeaseTime() time.Duration {
 	return 5 * c.KeepAliveInterval
 }
 
-type Delta float64
-
-// DefaultDelta is the default value to use with PlusMinusDelta
-const DefaultDelta Delta = 0.25
-
-// PlusMinusDelta returns a number [value - value * delta ≤ value ≤ value + value * delta]
-func PlusMinusDelta(value float64, delta Delta) float64 {
-	lower := float64(value) * (1.0 - float64(delta))
-	higher := float64(value) * (1.0 + float64(delta))
-	diff := higher - lower
-	rate := rand.Float64()
-	return lower + rate*diff
-}
-
-// PlusMinusDeltaDuration is a helper to manipulate time.Duration with PlusMinusDelta
-func PlusMinusDeltaDuration(value time.Duration, delta Delta) time.Duration {
-	res := PlusMinusDelta(float64(value), delta)
-	return time.Duration(int64(res))
+// RandomDurationAround returns a duration (1.0 - percent) * duration < n < (1.0 + percent) * duration
+func RandomDurationAround(duration time.Duration, scatteringPercentage float64) time.Duration {
+	delta := int64(float64(duration) * 2 * scatteringPercentage)
+	return time.Duration(int64(duration) + rand.Int63n(delta) - (delta / 2))
 }
 
 func Build() (Config, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlusMinusDelta(t *testing.T) {
+	occurrences := 100
+	for i := 0; i < occurrences; i++ {
+		res := PlusMinusDelta(1, DefaultDelta)
+		require.Truef(t, res >= 0.75, "valus is %v, should be >= 0.75", res)
+		require.Truef(t, res <= 1.25, "value is %v, should be <= 1.25", res)
+	}
+
+	for i := 0; i < occurrences; i++ {
+		res := PlusMinusDelta(1, Delta(0.5))
+		require.Truef(t, res >= 0.5, "valus is %v, should be >= 0.50", res)
+		require.Truef(t, res <= 1.5, "value is %v, should be <= 1.50", res)
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,21 +2,22 @@ package config
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestPlusMinusDelta(t *testing.T) {
+func TestRandomDurationAround(t *testing.T) {
 	occurrences := 100
 	for i := 0; i < occurrences; i++ {
-		res := PlusMinusDelta(1, DefaultDelta)
-		require.Truef(t, res >= 0.75, "valus is %v, should be >= 0.75", res)
-		require.Truef(t, res <= 1.25, "value is %v, should be <= 1.25", res)
+		res := RandomDurationAround(time.Second, 0.25)
+		require.Truef(t, res >= 750*time.Millisecond, "valus is %v, should be >= 750ms", res)
+		require.Truef(t, res <= 1250*time.Millisecond, "value is %v, should be <= 1.25s", res)
 	}
 
 	for i := 0; i < occurrences; i++ {
-		res := PlusMinusDelta(1, Delta(0.5))
-		require.Truef(t, res >= 0.5, "valus is %v, should be >= 0.50", res)
-		require.Truef(t, res <= 1.5, "value is %v, should be <= 1.50", res)
+		res := RandomDurationAround(time.Second, 0.50)
+		require.Truef(t, res >= 500*time.Millisecond, "valus is %v, should be >= 500ms", res)
+		require.Truef(t, res <= 1500*time.Millisecond, "value is %v, should be <= 1.50s", res)
 	}
 }

--- a/ip/network.go
+++ b/ip/network.go
@@ -65,7 +65,7 @@ func (m *manager) startArpEnsure(ctx context.Context) {
 			garpCount = 0
 		}
 
-		timeToSleep := config.PlusMinusDeltaDuration(m.config.ARPGratuitousInterval, config.DefaultDelta)
+		timeToSleep := config.RandomDurationAround(m.config.ARPGratuitousInterval, 0.25)
 		time.Sleep(timeToSleep)
 	}
 }

--- a/ip/network_test.go
+++ b/ip/network_test.go
@@ -89,7 +89,8 @@ func TestStartARPEnsure(t *testing.T) {
 	}
 
 	config := config.Config{
-		ARPGratuitousInterval: 100 * time.Millisecond,
+		ARPGratuitousInterval: 10 * time.Millisecond,
+		ARPGratuitousCount:    3,
 	}
 
 	t.Run("If the IP is activated", func(t *testing.T) {
@@ -99,7 +100,7 @@ func TestStartARPEnsure(t *testing.T) {
 		ctx := context.Background()
 
 		networkMock := networkmock.NewMockNetworkInterface(ctrl)
-		networkMock.EXPECT().EnsureIP(ip.IP).Return(nil).MinTimes(1)
+		networkMock.EXPECT().EnsureIP(ip.IP).Return(nil).MaxTimes(config.ARPGratuitousCount)
 		lockerMock := lockermock.NewMockLocker(ctrl)
 		lockerMock.EXPECT().Unlock(gomock.Any()).Return(nil)
 
@@ -118,7 +119,7 @@ func TestStartARPEnsure(t *testing.T) {
 			manager.startArpEnsure(ctx)
 			doneChan <- true
 		}()
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		manager.Stop(ctx, func(context.Context) error { return nil })
 
 		timer := time.NewTimer(500 * time.Millisecond)


### PR DESCRIPTION
gARP goal is to enfore a change of ARP tables in the infrastructure after a failover happens,
when the ACTIVATED node for an IP is changing. Thus it should not be sent continously but only
when a change happen.

That's what is describe here

https://www.practicalnetworking.net/series/arp/gratuitous-arp/

And applied in the VRRP protocol for instance

https://tools.ietf.org/html/rfc3768

Thus we're now only sending them at that moment, and then servers will answer normal ARPs requests afterwards, the three gARP should be enough to trigger the table update everywhere, it's what is done by keepalived

Fixes #79

The issue is fixed because it was related to the point that the service was sending continously too many gARP at the same time, now the number of gARP has been decreased
and some randomization has been added to avoid all gARPs to be sent at the same time