### PR TITLE
feat(migrations): add data migrations from v0 to v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/Scalingo/go-handlers v1.4.0
 	github.com/Scalingo/go-philae/v4 v4.4.2
+	github.com/Scalingo/go-utils/errors v1.0.0
 	github.com/Scalingo/go-utils/etcd v1.0.1
 	github.com/Scalingo/go-utils/logger v1.0.0
 	github.com/Scalingo/go-utils/retry v1.0.0

--- a/locker/etcd_lease_manager.go
+++ b/locker/etcd_lease_manager.go
@@ -56,7 +56,7 @@ type etcdLeaseManager struct {
 func NewEtcdLeaseManager(ctx context.Context, config config.Config, storage models.Storage, etcd *clientv3.Client) EtcdLeaseManager {
 	return &etcdLeaseManager{
 		stopper:            make(chan bool, 1),
-		leaseDirtyNotifier: make(chan clientv3.LeaseID),
+		leaseDirtyNotifier: make(chan clientv3.LeaseID, 1),
 		leaseErrorNotifier: make(chan bool, 1),
 		leases:             etcd,
 		kv:                 etcd,

--- a/locker/etcd_lease_manager.go
+++ b/locker/etcd_lease_manager.go
@@ -95,8 +95,9 @@ func (m *etcdLeaseManager) GetLease(ctx context.Context) (clientv3.LeaseID, erro
 	}
 	defer m.UnsubscribeToLeaseChange(ctx, id) // Do not forget to clean it
 
-	// Prepare a timer (to manage tiemout) this timer should not be above the KeepAliveInterval
-	timer := time.NewTimer(m.config.KeepAliveInterval)
+	// Prepare a timer (to manage tiemout) this timer should not be above the KeepAliveInterval.
+	// The timer is just a safeguard to prevent a goroutine to wait indefinitely.
+	timer := time.NewTimer(2 * m.config.KeepAliveInterval)
 	select {
 	case <-timer.C:
 		// If the command timed out

--- a/locker/etcd_lease_manager.go
+++ b/locker/etcd_lease_manager.go
@@ -17,10 +17,10 @@ import (
 const DataVersion = 1
 
 // ErrCallbackNotFound is launched when a user tries to delete a callback that does not exist
-var ErrCallbackNotFound = errors.New("Lease callback not found")
+var ErrCallbackNotFound = errors.New("lease callback not found")
 
 // ErrGetLeaseTimeout is launched when a user calls GetLease and we fail to provide one in time
-var ErrGetLeaseTimeout = errors.New("Timeout while trying to get lease")
+var ErrGetLeaseTimeout = errors.New("timeout while trying to get lease")
 
 // LeaseChangedCallback is a callback called by the lease manager when the leaseID has changed so that all managers could try to regenerate their keys
 type LeaseChangedCallback func(ctx context.Context, oldLeaseID, newLeaseID clientv3.LeaseID)

--- a/locker/etcd_lease_manager.go
+++ b/locker/etcd_lease_manager.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	scalingoerrors "github.com/Scalingo/go-utils/errors"
 	"github.com/Scalingo/go-utils/logger"
 	"github.com/Scalingo/link/config"
 	"github.com/Scalingo/link/models"
@@ -143,7 +144,7 @@ func (m *etcdLeaseManager) Start(ctx context.Context) error {
 	// not have any guarantee that we are the one that will take those locks.
 	log.Info("Getting old leaseID")
 	host, err := m.storage.GetCurrentHost(ctx)
-	if err != nil && err != models.ErrHostNotFound {
+	if err != nil && scalingoerrors.RootCause(err) != models.ErrHostNotFound {
 		return errors.Wrap(err, "fail to find host config")
 	}
 	if host.LeaseID != 0 {

--- a/locker/etcd_lease_manager.go
+++ b/locker/etcd_lease_manager.go
@@ -165,6 +165,7 @@ func (m *etcdLeaseManager) Start(ctx context.Context) error {
 	} else {
 		log.Info("LeaseID not found, starting with LeaseID=0")
 		m.forceLeaseRefresh = true
+		m.leaseDirtyNotifier <- m.leaseID
 	}
 
 	_, err = m.SubscribeToLeaseChange(ctx, m.storeLeaseChange)

--- a/locker/etcd_locker.go
+++ b/locker/etcd_locker.go
@@ -106,7 +106,6 @@ func (l *etcdLocker) Unlock(ctx context.Context) error {
 }
 
 func (l *etcdLocker) IsMaster(ctx context.Context) (bool, error) {
-	log := logger.Get(ctx)
 	// We do know that we are the master if:
 	// - The key exist
 	// - The lease associated to this key is our lease
@@ -126,7 +125,6 @@ func (l *etcdLocker) IsMaster(ctx context.Context) (bool, error) {
 		return false, errors.Wrap(err, "fail to get current lease ID from manager")
 	}
 
-	log.Debugf("%v =? %v", resp.Kvs[0].Lease, leaseID)
 	return resp.Kvs[0].Lease == int64(leaseID), nil
 }
 

--- a/locker/etcd_locker.go
+++ b/locker/etcd_locker.go
@@ -65,7 +65,7 @@ func (l *etcdLocker) Refresh(ctx context.Context) error {
 	}
 
 	// The goal of this transaction is to create the key with our leaseID only if this key does not exist
-	// We use a transaction to make sure that concurrent tries wont interfere with each others.
+	// We use a transaction to make sure that concurrent tries won't interfere with each others.
 
 	transactionCtx, cancel := context.WithTimeout(ctx, l.config.KeepAliveInterval)
 	defer cancel()

--- a/locker/etcd_locker.go
+++ b/locker/etcd_locker.go
@@ -152,9 +152,8 @@ func (l *etcdLocker) leaseChanged(ctx context.Context, oldLeaseID, newLeaseID cl
 		// Replace it with the newLease
 		Then(clientv3.OpPut(l.key, l.config.Hostname, clientv3.WithLease(newLeaseID))).
 		Commit()
-
 	if err != nil {
-		log.WithError(err).Errorf("fail to change lease of key %s", l.key)
+		log.WithError(err).Errorf("Fail to change lease of key %s", l.key)
 	}
 }
 

--- a/locker/etcd_locker.go
+++ b/locker/etcd_locker.go
@@ -106,6 +106,7 @@ func (l *etcdLocker) Unlock(ctx context.Context) error {
 }
 
 func (l *etcdLocker) IsMaster(ctx context.Context) (bool, error) {
+	log := logger.Get(ctx)
 	// We do know that we are the master if:
 	// - The key exist
 	// - The lease associated to this key is our lease
@@ -125,6 +126,7 @@ func (l *etcdLocker) IsMaster(ctx context.Context) (bool, error) {
 		return false, errors.Wrap(err, "fail to get current lease ID from manager")
 	}
 
+	log.Debugf("%v =? %v", resp.Kvs[0].Lease, leaseID)
 	return resp.Kvs[0].Lease == int64(leaseID), nil
 }
 

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 				"id": ip.ID,
 				"ip": ip.IP,
 			})
-			log.Info("Starting")
+			log.Info("Starting an IP scheduler")
 			_, err := scheduler.Start(logger.ToCtx(ctx, log), ip)
 			if err != nil {
 				panic(err)

--- a/migrations/etcd_storage_v0.go
+++ b/migrations/etcd_storage_v0.go
@@ -1,0 +1,92 @@
+package migrations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Scalingo/link/models"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/v3/clientv3"
+)
+
+// v0IP represents an virtual IP as stored in the v0 data version. The main difference as compared to v1 is the LeaseID.
+type v0IP struct {
+	ID      string `json:"id"`
+	IP      string `json:"ip"`
+	LeaseID int64  `json:"lease_id,omitempty"`
+}
+
+func (v0IP v0IP) convertToV1() models.IP {
+	return models.IP{
+		ID: v0IP.ID,
+		IP: v0IP.IP,
+	}
+}
+
+type v0EtcdStorage struct {
+	etcdClient     clientv3.KV
+	leaseManagerID clientv3.LeaseID
+}
+
+func newV0EtcdStorage(etcdClient clientv3.KV, leaseManagerID clientv3.LeaseID) v0EtcdStorage {
+	return v0EtcdStorage{
+		etcdClient:     etcdClient,
+		leaseManagerID: leaseManagerID,
+	}
+}
+
+// getIPs gets in etcd the list of virtual IPs on the given host. It parses the result in the v0 data version.
+func (e v0EtcdStorage) getIPs(ctx context.Context, hostname string) ([]v0IP, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	resp, err := e.etcdClient.Get(ctx, fmt.Sprintf("%s/hosts/%s", models.EtcdLinkDirectory, hostname), clientv3.WithPrefix())
+	if err != nil {
+		return nil, errors.Wrap(err, "fail to get list of IPs from etcd")
+	}
+
+	ips := make([]v0IP, 0)
+	for _, kv := range resp.Kvs {
+		var ip v0IP
+		err := json.Unmarshal(kv.Value, &ip)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid json for %s", kv.Key)
+		}
+		ips = append(ips, ip)
+	}
+	return ips, nil
+}
+
+// isMaster checks if the given vIP in v0 data version is master.
+func (e v0EtcdStorage) isMaster(ctx context.Context, ip v0IP) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	key := fmt.Sprintf("%s/default/%s", models.EtcdLinkDirectory, strings.Replace(ip.IP, "/", "_", -1))
+	resp, err := e.etcdClient.Get(ctx, key)
+	if err != nil {
+		return false, errors.Wrapf(err, "fail to get lock of the IP %s", ip.IP)
+	}
+
+	if len(resp.Kvs) != 1 {
+		return false, fmt.Errorf("invalid etcd state (key '%s' not found!)", key)
+	}
+
+	return resp.Kvs[0].Lease == int64(ip.LeaseID), nil
+}
+
+// putIP puts the v1 IP in the new etcd key.
+func (e v0EtcdStorage) putIP(ctx context.Context, ip models.IP, hostname string) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	key := fmt.Sprintf("%s/default/%s", models.EtcdLinkDirectory, ip.StorableIP())
+	_, err := e.etcdClient.Put(ctx, key, hostname, clientv3.WithLease(e.leaseManagerID))
+	if err != nil {
+		return errors.Wrapf(err, "fail to put the IP '%s' in etcd", ip.StorableIP())
+	}
+	return nil
+}

--- a/migrations/v0_to_v1.go
+++ b/migrations/v0_to_v1.go
@@ -70,6 +70,7 @@ func (m V0toV1) Migrate(ctx context.Context) error {
 		return errors.Wrap(err, "fail to get the list of v0 IPs")
 	}
 
+	// TODO in case of error in this loop, do not return but log and continue
 	for _, ip := range ips {
 		log := log.WithFields(logrus.Fields{
 			"id":       ip.ID,
@@ -87,9 +88,16 @@ func (m V0toV1) Migrate(ctx context.Context) error {
 		}
 
 		log.Info("Host is master of this IP, migrate the data")
-		err = v0Storage.putIP(ctx, ip.convertToV1(), m.hostname)
+		ipV1 := ip.convertToV1()
+		err = v0Storage.putIP(ctx, ipV1, m.hostname)
 		if err != nil {
 			return errors.Wrap(err, "fail to update the IP data during the migration from v0 to v1")
+		}
+
+		// We link again the IP with the current host to trigger the topology change in the IP manager
+		err = m.storage.LinkIPWithCurrentHost(ctx, ipV1)
+		if err != nil {
+			return errors.Wrap(err, "fail to link IP with the current host during the migration from v0 to v1")
 		}
 	}
 

--- a/migrations/v0_to_v1.go
+++ b/migrations/v0_to_v1.go
@@ -1,0 +1,91 @@
+package migrations
+
+import (
+	"context"
+	"io"
+
+	"github.com/Scalingo/go-utils/etcd"
+	"github.com/Scalingo/go-utils/logger"
+	"github.com/Scalingo/link/locker"
+	"github.com/Scalingo/link/models"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/v3/clientv3"
+)
+
+type V0toV1 struct {
+	// TODO Do we need the lease manager
+	leaseManager locker.EtcdLeaseManager
+	storage      models.Storage
+}
+
+func NewV0toV1Migration(leaseManager locker.EtcdLeaseManager, storage models.Storage) V0toV1 {
+	return V0toV1{
+		leaseManager: leaseManager,
+		storage:      storage,
+	}
+}
+
+func (m V0toV1) NeedsMigration(ctx context.Context) bool {
+	log := logger.Get(ctx)
+	log.Info("Data migration from v0 to v1 is needed")
+	// TODO
+	return false
+}
+
+func (m V0toV1) Migrate(ctx context.Context) error {
+	log := logger.Get(ctx)
+	log.Info("Migrate data from v0 to v1")
+
+	host, err := m.storage.GetCurrentHost(ctx)
+	if err != nil {
+		return errors.Wrap(err, "fail to get the current host information to migrate data from v0 to v1")
+	}
+
+	etcdClient, closer, err := newEtcdClient()
+	if err != nil {
+		return errors.Wrap(err, "fail to create etcd client to migrate data from v0 to v1")
+	}
+	defer closer.Close()
+
+	v0Storage := newV0EtcdStorage(etcdClient, clientv3.LeaseID(host.LeaseID))
+	ips, err := v0Storage.getIPs(ctx, host.Hostname)
+	if err != nil {
+		return errors.Wrap(err, "fail to get the list of v0 IPs")
+	}
+
+	for _, ip := range ips {
+		log := log.WithFields(logrus.Fields{
+			"id":       ip.ID,
+			"ip":       ip.IP,
+			"lease_id": ip.LeaseID,
+		})
+
+		isMaster, err := v0Storage.isMaster(ctx, ip)
+		if err != nil {
+			return errors.Wrap(err, "fail to get the master status of the IP")
+		}
+		if !isMaster {
+			log.Info("Host is not master of this IP, nothing to do")
+			continue
+		}
+
+		log.Info("Host is master of this IP, migrate the data")
+		err = v0Storage.putIP(ctx, ip.convertToV1(), host.Hostname)
+		if err != nil {
+			return errors.Wrap(err, "fail to update the IP data during the migration from v0 to v1")
+		}
+	}
+
+	log.Info("End of the data migration from v0 to v1")
+	return nil
+}
+
+func newEtcdClient() (clientv3.KV, io.Closer, error) {
+	c, err := etcd.ClientFromEnv()
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "fail to get etcd client from config")
+	}
+
+	return clientv3.KV(c), c, nil
+}

--- a/models/etcd_storage.go
+++ b/models/etcd_storage.go
@@ -26,7 +26,7 @@ const (
 
 var (
 	ErrIPAlreadyPresent = errors.New("IP already present")
-	ErrHostNotFound     = errors.New("Host not found")
+	ErrHostNotFound     = errors.New("host not found")
 )
 
 type etcdStorage struct {

--- a/models/etcd_storage.go
+++ b/models/etcd_storage.go
@@ -40,7 +40,7 @@ func NewEtcdStorage(config config.Config) etcdStorage {
 }
 
 func (e etcdStorage) GetIPs(ctx context.Context) ([]IP, error) {
-	client, closer, err := e.NewEtcdClient()
+	client, closer, err := e.newEtcdClient()
 	if err != nil {
 		return nil, errors.Wrap(err, "fail to get etcd client")
 	}
@@ -78,7 +78,7 @@ func (e etcdStorage) AddIP(ctx context.Context, ip IP) (IP, error) {
 		}
 	}
 
-	client, closer, err := e.NewEtcdClient()
+	client, closer, err := e.newEtcdClient()
 	if err != nil {
 		return ip, errors.Wrap(err, "fail to get etcd client")
 	}
@@ -114,7 +114,7 @@ func (e etcdStorage) UpdateIP(ctx context.Context, ip IP) error {
 		return fmt.Errorf("invalid IP ID: %s", ip.IP)
 	}
 
-	client, closer, err := e.NewEtcdClient()
+	client, closer, err := e.newEtcdClient()
 	if err != nil {
 		return errors.Wrap(err, "fail to open client")
 	}
@@ -136,7 +136,7 @@ func (e etcdStorage) UpdateIP(ctx context.Context, ip IP) error {
 }
 
 func (e etcdStorage) RemoveIP(ctx context.Context, id string) error {
-	client, closer, err := e.NewEtcdClient()
+	client, closer, err := e.newEtcdClient()
 	if err != nil {
 		return errors.Wrap(err, "fail to get etcd client")
 	}
@@ -163,7 +163,7 @@ func (e etcdStorage) GetCurrentHost(ctx context.Context) (Host, error) {
 
 func (e etcdStorage) getHost(ctx context.Context, hostname string) (Host, error) {
 	var host Host
-	client, close, err := e.NewEtcdClient()
+	client, close, err := e.newEtcdClient()
 	if err != nil {
 		return host, errors.Wrap(err, "fail to get etcd client")
 	}
@@ -190,7 +190,7 @@ func (e etcdStorage) getHost(ctx context.Context, hostname string) (Host, error)
 }
 
 func (e etcdStorage) SaveHost(ctx context.Context, host Host) error {
-	client, closer, err := e.NewEtcdClient()
+	client, closer, err := e.newEtcdClient()
 	if err != nil {
 		return errors.Wrap(err, "fail to get etcd client")
 	}
@@ -213,7 +213,7 @@ func (e etcdStorage) SaveHost(ctx context.Context, host Host) error {
 
 func (e etcdStorage) LinkIPWithCurrentHost(ctx context.Context, ip IP) error {
 	key := fmt.Sprintf("%s/ips/%s/%s", EtcdLinkDirectory, ip.StorableIP(), e.hostname)
-	client, closer, err := e.NewEtcdClient()
+	client, closer, err := e.newEtcdClient()
 	if err != nil {
 		return errors.Wrap(err, "fail to get etcd client")
 	}
@@ -237,7 +237,7 @@ func (e etcdStorage) LinkIPWithCurrentHost(ctx context.Context, ip IP) error {
 
 func (e etcdStorage) UnlinkIPFromCurrentHost(ctx context.Context, ip IP) error {
 	key := fmt.Sprintf("%s/ips/%s/%s", EtcdLinkDirectory, ip.StorableIP(), e.hostname)
-	client, closer, err := e.NewEtcdClient()
+	client, closer, err := e.newEtcdClient()
 	if err != nil {
 		return errors.Wrap(err, "fail to get etcd client")
 	}
@@ -255,7 +255,7 @@ func (e etcdStorage) UnlinkIPFromCurrentHost(ctx context.Context, ip IP) error {
 func (e etcdStorage) GetIPHosts(ctx context.Context, ip IP) ([]string, error) {
 	key := fmt.Sprintf("%s/ips/%s", EtcdLinkDirectory, ip.StorableIP())
 
-	client, closer, err := e.NewEtcdClient()
+	client, closer, err := e.newEtcdClient()
 	if err != nil {
 		return nil, errors.Wrap(err, "fail to get etcd client")
 	}
@@ -276,7 +276,7 @@ func (e etcdStorage) GetIPHosts(ctx context.Context, ip IP) ([]string, error) {
 	return results, nil
 }
 
-func (e etcdStorage) NewEtcdClient() (clientv3.KV, io.Closer, error) {
+func (e etcdStorage) newEtcdClient() (clientv3.KV, io.Closer, error) {
 	c, err := etcd.ClientFromEnv()
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "fail to get etcd client from config")

--- a/models/host.go
+++ b/models/host.go
@@ -4,4 +4,6 @@ package models
 type Host struct {
 	Hostname string `json:"hostname"` // Hostname of this host
 	LeaseID  int64  `json:"lease_id"` // LeaseID current lease ID of this host
+	// DataVersion is the version number of how the data is stored in etcd for this host. This field is introduced in 2.0.0. But the data format version v0 correspond to the format before v1.9.0.
+	DataVersion int `json:"data_version,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,6 +7,7 @@ github.com/Scalingo/go-philae/v4/prober
 github.com/Scalingo/go-philae/v4/sampleprobe
 github.com/Scalingo/go-philae/v4/tcpprobe
 # github.com/Scalingo/go-utils/errors v1.0.0
+## explicit
 github.com/Scalingo/go-utils/errors
 # github.com/Scalingo/go-utils/etcd v1.0.1
 ## explicit


### PR DESCRIPTION
A LinK IP has been created in LinK v1.8.4:
```
+------------------------------------------+-----------------+-----------+------------------------------------------+
|                    ID                    |       IP        |  STATUS   |                  CHECKS                  |
+------------------------------------------+-----------------+-----------+------------------------------------------+
| vip-e927f963-3a71-421c-8948-a1e557936d54 | 10.127.128.2/32 | ACTIVATED | TCP -                                    |
|                                          |                 |           | node-1-dev.172.17.0.1.xip.st-sc.fr:30024 |
+------------------------------------------+-----------------+-----------+------------------------------------------+
+----+----+--------+--------+
| ID | IP | STATUS | CHECKS |
+----+----+--------+--------+
+----+----+--------+--------+
+----+----+--------+--------+
| ID | IP | STATUS | CHECKS |
+----+----+--------+--------+
+----+----+--------+--------+
```

Data in etcd:

```
╰─$ docker run --rm --env ETCDCTL_API=3 quay.io/coreos/etcd:v3.4.16 etcdctl --endpoints http://172.17.0.1:32379 get --prefix /link
/link/default/10.127.128.2_32
locked
/link/hosts/link-1/vip-e927f963-3a71-421c-8948-a1e557936d54
{"id":"vip-e927f963-3a71-421c-8948-a1e557936d54","ip":"10.127.128.2/32","lease_id":8641979253341292297,"checks":[{"type":"TCP","host":"node-1-dev.172.17.0.1.xip.st-sc.fr","port":30024}],"keepalive_interval":1800,"healthcheck_interval":0}
```

Then I executed this branch and migration succeeded and the IP is always ACTIVATED:

```
╰─$ docker run --rm --env ETCDCTL_API=3 quay.io/coreos/etcd:v3.4.16 etcdctl --endpoints http://172.17.0.1:32379 get --prefix /link
/link/config/link-1
{"hostname":"link-1","lease_id":8641979254679888911,"data_version":1}
/link/config/link-2
{"hostname":"link-2","lease_id":8641979254679888915,"data_version":1}
/link/config/link-3
{"hostname":"link-3","lease_id":8641979254679888913,"data_version":1}
/link/default/10.127.128.2_32
link-1
/link/hosts/link-1/vip-e927f963-3a71-421c-8948-a1e557936d54
{"id":"vip-e927f963-3a71-421c-8948-a1e557936d54","ip":"10.127.128.2/32","lease_id":8641979253341292297,"checks":[{"type":"TCP","host":"node-1-dev.172.17.0.1.xip.st-sc.fr","port":30024}],"keepalive_interval":1800,"healthcheck_interval":0}
/link/ips/10.127.128.2_32/link-1
{"updated_at":"2021-06-29T15:07:26.963864653Z"}
```

There is no downtime during the process.

Fix #116