### PR TITLE
feature(no_network) Add an option to disable any network activity on the NIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## To be released
 
+* Add the no-network option to disable any operation on the NIC (do not add the IP and do not perform Gratuitous ARP)
+* Add the update command on link client that let user change options on an IP
+
 ## [2021-08-23] v2.0.1
 
 * chore(deps): bump github.com/olekukonko/tablewriter v0.0.0-20180912035003-be2c049b30cc => v0.0.5

--- a/api/http_client.go
+++ b/api/http_client.go
@@ -150,6 +150,7 @@ func (c HTTPClient) Failover(ctx context.Context, id string) error {
 type AddIPParams struct {
 	HealthcheckInterval int                  `json:"healthcheck_interval"`
 	Checks              []models.Healthcheck `json:"checks"`
+	NoNetwork           bool                 `json:"no_network"`
 }
 
 func (c HTTPClient) AddIP(ctx context.Context, ip string, params AddIPParams) (IP, error) {
@@ -158,6 +159,7 @@ func (c HTTPClient) AddIP(ctx context.Context, ip string, params AddIPParams) (I
 		IP:                  ip,
 		HealthcheckInterval: params.HealthcheckInterval,
 		Checks:              params.Checks,
+		NoNetwork:           params.NoNetwork,
 	})
 	if err != nil {
 		return IP{}, err
@@ -189,6 +191,7 @@ func (c HTTPClient) AddIP(ctx context.Context, ip string, params AddIPParams) (I
 
 type UpdateIPParams struct {
 	Healthchecks []models.Healthcheck `json:"healthchecks"`
+	NoNetwork    *bool                `json:"no_network"`
 }
 
 func (c HTTPClient) UpdateIP(ctx context.Context, id string, params UpdateIPParams) (IP, error) {

--- a/cmd/link-client/formatter.go
+++ b/cmd/link-client/formatter.go
@@ -15,7 +15,7 @@ import (
 func formatIPs(ips []api.IP) {
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"ID", "IP", "Status", "CHECKS"})
+	table.SetHeader([]string{"ID", "IP", "Status", "Checks", "Options"})
 
 	for _, ip := range ips {
 		status := formatStatus(ip)
@@ -29,11 +29,22 @@ func formatIPs(ips []api.IP) {
 
 			checks = strings.Join(c, ",")
 		}
+
+		optionsArr := make([]string, 0)
+		if ip.NoNetwork {
+			optionsArr = append(optionsArr, "no-network")
+		}
+		options := "-"
+		if len(optionsArr) != 0 {
+			options = strings.Join(optionsArr, ", ")
+		}
+
 		table.Append([]string{
 			ip.ID,
 			ip.IP.IP,
 			status,
 			checks,
+			options,
 		})
 	}
 	table.Render()
@@ -42,6 +53,7 @@ func formatIPs(ips []api.IP) {
 func formatIP(ip api.IP) {
 	fmt.Printf("ID:\t%s\n", ip.ID)
 	fmt.Printf("Status:\t%s\n", formatStatus(ip))
+	fmt.Printf("No Network:\t%v\n", ip.NoNetwork)
 	if len(ip.Checks) == 0 {
 		fmt.Printf("Checks:\tNone\n")
 	} else {

--- a/ip/manager_test.go
+++ b/ip/manager_test.go
@@ -1,0 +1,70 @@
+package ip
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Scalingo/link/v2/models"
+	"github.com/Scalingo/link/v2/network/networkmock"
+	"github.com/golang/mock/gomock"
+	"github.com/looplab/fsm"
+)
+
+func TestUpdateIP(t *testing.T) {
+	examples := map[string]struct {
+		oldIP                  models.IP
+		newIP                  models.IP
+		state                  string
+		expectNetworkInterface func(mock *networkmock.MockNetworkInterface)
+	}{
+		"if the old and new ip has the no no_network flag": {
+			oldIP: models.IP{NoNetwork: true},
+			newIP: models.IP{NoNetwork: true},
+		},
+		"if the old and new ip doesn't have the no_network flag": {
+			oldIP: models.IP{NoNetwork: false},
+			newIP: models.IP{NoNetwork: false},
+		},
+		"if the user enable the no_network flag": {
+			oldIP: models.IP{NoNetwork: false},
+			newIP: models.IP{IP: "10.10.10.10/32", NoNetwork: true},
+			expectNetworkInterface: func(mock *networkmock.MockNetworkInterface) {
+				mock.EXPECT().RemoveIP("10.10.10.10/32")
+			},
+		},
+		"if the user disable the no_network flag and we are not master": {
+			oldIP: models.IP{NoNetwork: true},
+			newIP: models.IP{IP: "10.10.10.10/32", NoNetwork: false},
+			state: STANDBY,
+		},
+		"if the user disable the no_network flag and we are master": {
+			oldIP: models.IP{NoNetwork: true},
+			newIP: models.IP{IP: "10.10.10.10/32", NoNetwork: false},
+			state: ACTIVATED,
+			expectNetworkInterface: func(mock *networkmock.MockNetworkInterface) {
+				mock.EXPECT().EnsureIP("10.10.10.10/32")
+			},
+		},
+	}
+
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockNetworkInterface := networkmock.NewMockNetworkInterface(ctrl)
+
+			if example.expectNetworkInterface != nil {
+				example.expectNetworkInterface(mockNetworkInterface)
+			}
+
+			manager := manager{
+				ip:               example.oldIP,
+				stateMachine:     fsm.NewFSM(example.state, fsm.Events{}, fsm.Callbacks{}),
+				networkInterface: mockNetworkInterface,
+			}
+
+			manager.UpdateIP(context.Background(), example.newIP)
+		})
+	}
+}

--- a/ip/network_test.go
+++ b/ip/network_test.go
@@ -14,72 +14,137 @@ import (
 )
 
 func TestSetActivated(t *testing.T) {
-	t.Run("It should call EnsureIP", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+	ip := models.IP{
+		IP: "10.0.0.1/32",
+		ID: "test-1234",
+	}
 
-		networkMock := networkmock.NewMockNetworkInterface(ctrl)
+	examples := map[string]struct {
+		noNetwork              bool
+		expectNetworkInterface func(mock *networkmock.MockNetworkInterface)
+	}{
+		"when no_netwok is set to false, add the IP": {
+			noNetwork: false,
+			expectNetworkInterface: func(mock *networkmock.MockNetworkInterface) {
+				mock.EXPECT().EnsureIP(ip.IP).Return(nil)
+			},
+		},
+		"when no_network is set to true, do nothing": {
+			noNetwork: true,
+		},
+	}
 
-		ip := models.IP{
-			IP: "10.0.0.1/32",
-			ID: "test-1234",
-		}
-		networkMock.EXPECT().EnsureIP(ip.IP).Return(nil)
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-		manager := &manager{
-			networkInterface: networkMock,
-			ip:               ip,
-		}
+			networkMock := networkmock.NewMockNetworkInterface(ctrl)
 
-		manager.setActivated(context.Background(), &fsm.Event{})
-	})
+			if example.expectNetworkInterface != nil {
+				example.expectNetworkInterface(networkMock)
+			}
+
+			ip.NoNetwork = example.noNetwork
+
+			manager := &manager{
+				networkInterface: networkMock,
+				ip:               ip,
+			}
+
+			manager.setActivated(context.Background(), &fsm.Event{})
+		})
+	}
 }
 
 func TestSetStandBy(t *testing.T) {
-	t.Run("It should call RemoveIP", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+	ip := models.IP{
+		IP: "10.0.0.1/32",
+		ID: "test-1234",
+	}
 
-		ip := models.IP{
-			IP: "10.0.0.1/32",
-			ID: "test-1234",
-		}
+	examples := map[string]struct {
+		noNetwork              bool
+		expectNetworkInterface func(mock *networkmock.MockNetworkInterface)
+	}{
+		"when no_netwok is set to false, remove the IP": {
+			noNetwork: false,
+			expectNetworkInterface: func(mock *networkmock.MockNetworkInterface) {
+				mock.EXPECT().RemoveIP(ip.IP).Return(nil)
+			},
+		},
+		"when no_network is set to true, do nothing": {
+			noNetwork: true,
+		},
+	}
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-		networkMock := networkmock.NewMockNetworkInterface(ctrl)
-		networkMock.EXPECT().RemoveIP(ip.IP).Return(nil)
+			networkMock := networkmock.NewMockNetworkInterface(ctrl)
 
-		manager := &manager{
-			networkInterface: networkMock,
-			ip:               ip,
-		}
+			if example.expectNetworkInterface != nil {
+				example.expectNetworkInterface(networkMock)
+			}
 
-		manager.setStandBy(context.Background(), &fsm.Event{})
-	})
+			ip.NoNetwork = example.noNetwork
+
+			manager := &manager{
+				networkInterface: networkMock,
+				ip:               ip,
+			}
+
+			manager.setStandBy(context.Background(), &fsm.Event{})
+		})
+	}
 }
 
 func TestSetFailing(t *testing.T) {
-	t.Run("It remove the IP and stop the locker", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+	ip := models.IP{
+		IP: "10.0.0.1/32",
+		ID: "test-1234",
+	}
 
-		networkMock := networkmock.NewMockNetworkInterface(ctrl)
-		lockerMock := lockermock.NewMockLocker(ctrl)
+	examples := map[string]struct {
+		noNetwork              bool
+		expectNetworkInterface func(mock *networkmock.MockNetworkInterface)
+	}{
+		"when no_netwok is set to false, remove the IP and stop the locker": {
+			noNetwork: false,
+			expectNetworkInterface: func(mock *networkmock.MockNetworkInterface) {
+				mock.EXPECT().RemoveIP(ip.IP).Return(nil)
+			},
+		},
+		"when no_network is set to true, only stop the locker": {
+			noNetwork: true,
+		},
+	}
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-		ip := models.IP{
-			IP: "10.0.0.1/32",
-			ID: "test-1234",
-		}
-		networkMock.EXPECT().RemoveIP(ip.IP).Return(nil)
-		lockerMock.EXPECT().Unlock(gomock.Any()).Return(nil)
+			networkMock := networkmock.NewMockNetworkInterface(ctrl)
+			lockerMock := lockermock.NewMockLocker(ctrl)
+			lockerMock.EXPECT().Unlock(gomock.Any()).Return(nil)
 
-		manager := &manager{
-			networkInterface: networkMock,
-			locker:           lockerMock,
-			ip:               ip,
-		}
+			if example.expectNetworkInterface != nil {
+				example.expectNetworkInterface(networkMock)
+			}
 
-		manager.setFailing(context.Background(), &fsm.Event{})
-	})
+			ip.NoNetwork = example.noNetwork
+
+			manager := &manager{
+				networkInterface: networkMock,
+				locker:           lockerMock,
+				ip:               ip,
+			}
+
+			manager.setFailing(context.Background(), &fsm.Event{})
+		})
+	}
+
 }
 
 func TestStartARPEnsure(t *testing.T) {
@@ -93,75 +158,67 @@ func TestStartARPEnsure(t *testing.T) {
 		ARPGratuitousCount:    3,
 	}
 
-	t.Run("If the IP is activated", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+	examples := map[string]struct {
+		state                  string
+		noNetwork              bool
+		expectNetworkInterface func(mock *networkmock.MockNetworkInterface)
+	}{
+		"if the IP is activated": {
+			state: ACTIVATED,
+			expectNetworkInterface: func(mock *networkmock.MockNetworkInterface) {
+				mock.EXPECT().EnsureIP(ip.IP).Return(nil).MaxTimes(config.ARPGratuitousCount)
+			},
+		},
+		"if the IP is activated but no_network is set to true": {
+			state:     ACTIVATED,
+			noNetwork: true,
+		},
+		"if the IP is not activated": {
+			state: STANDBY,
+		},
+	}
 
-		ctx := context.Background()
+	for name, example := range examples {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-		networkMock := networkmock.NewMockNetworkInterface(ctrl)
-		networkMock.EXPECT().EnsureIP(ip.IP).Return(nil).MaxTimes(config.ARPGratuitousCount)
+			ctx := context.Background()
 
-		sm := NewStateMachine(ctx, NewStateMachineOpts{})
-		sm.SetState(ACTIVATED)
-		manager := &manager{
-			networkInterface: networkMock,
-			stateMachine:     sm,
-			config:           config,
-			ip:               ip,
-		}
+			networkMock := networkmock.NewMockNetworkInterface(ctrl)
+			if example.expectNetworkInterface != nil {
+				example.expectNetworkInterface(networkMock)
+			}
 
-		doneChan := make(chan bool)
-		go func() {
-			manager.startArpEnsure(ctx)
-			doneChan <- true
-		}()
-		time.Sleep(100 * time.Millisecond)
+			sm := NewStateMachine(ctx, NewStateMachineOpts{})
+			sm.SetState(example.state)
 
-		manager.stopMutex.Lock()
-		manager.stopped = true
-		manager.stopMutex.Unlock()
+			ip.NoNetwork = example.noNetwork
 
-		timer := time.NewTimer(500 * time.Millisecond)
-		select {
-		case <-timer.C:
-			t.Fatal("NOT RESPONDING")
-		case <-doneChan:
-		}
-	})
+			manager := &manager{
+				networkInterface: networkMock,
+				stateMachine:     sm,
+				config:           config,
+				ip:               ip,
+			}
 
-	t.Run("If the IP is not activated", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
+			doneChan := make(chan bool)
+			go func() {
+				manager.startArpEnsure(ctx)
+				doneChan <- true
+			}()
+			time.Sleep(100 * time.Millisecond)
 
-		ctx := context.Background()
-		networkMock := networkmock.NewMockNetworkInterface(ctrl)
-		sm := NewStateMachine(ctx, NewStateMachineOpts{})
-		sm.SetState(FAILING)
-		manager := &manager{
-			networkInterface: networkMock,
-			stateMachine:     sm,
-			config:           config,
-			ip:               ip,
-		}
+			manager.stopMutex.Lock()
+			manager.stopped = true
+			manager.stopMutex.Unlock()
 
-		doneChan := make(chan bool)
-		go func() {
-			manager.startArpEnsure(ctx)
-			doneChan <- true
-		}()
-		time.Sleep(50 * time.Millisecond)
-
-		manager.stopMutex.Lock()
-		manager.stopped = true
-		manager.stopMutex.Unlock()
-
-		timer := time.NewTimer(500 * time.Millisecond)
-		select {
-		case <-timer.C:
-			t.Fatal("NOT RESPONDING")
-		case <-doneChan:
-		}
-	})
-
+			timer := time.NewTimer(500 * time.Millisecond)
+			select {
+			case <-timer.C:
+				t.Fatal("NOT RESPONDING")
+			case <-doneChan:
+			}
+		})
+	}
 }

--- a/models/ip.go
+++ b/models/ip.go
@@ -14,13 +14,15 @@ type IP struct {
 	Status              string        `json:"status,omitempty"`     // Status of this VIP
 	Checks              []Healthcheck `json:"checks,omitempty"`     // Healthcheck configured with this VIP
 	HealthcheckInterval int           `json:"healthcheck_interval"` // HealthcheckIntevals for this VIP
+	NoNetwork           bool          `json:"no_network"`           // Do not perform any actions on the NIC (do not add the IP and do not perform gratuitous ARP requests)
 }
 
 // ToLogrusFields returns a Logrus representation of an IP
 func (i IP) ToLogrusFields() logrus.Fields {
 	return logrus.Fields{
-		"ip":    i.IP,
-		"ip_id": i.ID,
+		"ip":         i.IP,
+		"ip_id":      i.ID,
+		"no_network": i.NoNetwork,
 	}
 }
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -193,5 +193,7 @@ func (s *IPScheduler) UpdateIP(ctx context.Context, ip models.IP) error {
 
 	manager.SetHealthchecks(ctx, s.config, ip.Checks)
 
+	manager.UpdateIP(ctx, ip)
+
 	return nil
 }

--- a/web/ip_controller.go
+++ b/web/ip_controller.go
@@ -151,6 +151,10 @@ func (c ipController) Patch(w http.ResponseWriter, r *http.Request, params map[s
 		return nil
 	}
 
+	if patchParams.NoNetwork != nil {
+		ip.NoNetwork = *patchParams.NoNetwork
+	}
+
 	ip.Checks = patchParams.Healthchecks
 	err = c.scheduler.UpdateIP(ctx, ip.IP)
 	if err != nil {


### PR DESCRIPTION
* Add NoNetwork option that prevent any Gratuitous ARP burst and the addition/removal of the IP on the NIC
* Add the update command on the link client that let's user customize VIP options

This is a first step toward #97 a next step would be to implements hooks on the FAILING, STANDBY and ACTIVATED state