### PR TITLE
fix(publish): disable CGO

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       run: |
         go install github.com/mitchellh/gox@latest
-        gox -os="linux" -arch="${{ env.GOX_ARCHITECTURES }}" -output="dist/link-${{ steps.tag_name.outputs.TAG_NAME }}-{{.OS}}-{{.Arch}}/{{.Dir}}" -ldflags="-X main.Version=${{ steps.tag_name.outputs.TAG_NAME }}" . ./cmd/...
+        CGO_ENABLED=0 gox -os="linux" -arch="${{ env.GOX_ARCHITECTURES }}" -output="dist/link-${{ steps.tag_name.outputs.TAG_NAME }}-{{.OS}}-{{.Arch}}/{{.Dir}}" -ldflags="-X main.Version=${{ steps.tag_name.outputs.TAG_NAME }}" . ./cmd/...
 
     - name: Archive the built binaries
       if: startsWith(github.ref, 'refs/tags/')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To be released
 
+* fix(publish): disable CGO
+
 ## [2024-10-02] v2.0.6
 
 * build(go): use go 1.22


### PR DESCRIPTION
I tested this on my fork: https://github.com/EtienneM/link/releases/tag/v2.0.8

Then I downloaded both the v2.0.6 and v2.0.8 in `/tmp` of one of our database hosting servers. v2.0.8 seems to have fixed the issue.

v2.0.6:

```
[osc-st-fr1] root@ip-10-0-0-242 (node) /tmp$ wget https://github.com/Scalingo/link/releases/download/v2.0.6/link-v2.0.6-linux-amd64.tar.gz
[osc-st-fr1] root@ip-10-0-0-242 (node) /tmp$ tar xvzf ./link-v2.0.6-linux-amd64.tar.gz 
[osc-st-fr1] root@ip-10-0-0-242 (node) /tmp$ cd link-v2.0.6-linux-amd64/
[osc-st-fr1] root@ip-10-0-0-242 (node) /tmp/link-v2.0.6-linux-amd64$ ./link --help
./link: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./link)
./link: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./link)
```

v2.0.8:

```
[osc-st-fr1] root@ip-10-0-0-242 (node) /tmp$ wget https://github.com/EtienneM/link/releases/download/v2.0.8/link-v2.0.8-linux-amd64.tar.gz                                                                                                                    
[osc-st-fr1] root@ip-10-0-0-242 (node) /tmp$ tar xvzf link-v2.0.8-linux-amd64.tar.gz 
[osc-st-fr1] root@ip-10-0-0-242 (node) /tmp$ cd link-v2.0.8-linux-amd64/
[osc-st-fr1] root@ip-10-0-0-242 (node) /tmp/link-v2.0.8-linux-amd64$ ./link --help
{"level":"warn","ts":"2024-10-14T13:57:51.712528Z","logger":"etcd-client","caller":"v3/retry_interceptor.go:63","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc00027c780/","attempt":0,"error":"rpc error: code = DeadlineExceeded des
c = latest balancer error: last connection error: connection error: desc = \"transport: Error while dialing: dial tcp: missing address\""}
panic: fail to get current host to check if it needs data migration from v0 to v1: fail to get current host: fail to get host from etcd: context deadline exceeded

goroutine 1 [running]:
main.main()
        /home/runner/work/link/link/main.go:52 +0x1e31
```

Hence I think that it fixes the issue.

Related to https://github.com/Scalingo/appsdeck-kitchen/issues/2313