### PR TITLE
refactor(ip) Rename IP to Endpoint to match the new model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,202 +2,204 @@
 
 ## To be released
 
+- refactor(IP): Rename any internal reference to the IP model to Endpoint
+
 ## [2024-10-14] v2.0.7
 
-* fix(publish): disable CGO
+- fix(publish): disable CGO
 
 ## [2024-10-02] v2.0.6
 
-* build(go): use go 1.22
-* build: various dependencies updates
+- build(go): use go 1.22
+- build: various dependencies updates
 
 ## [2023-12-27] v2.0.5
 
-* chore(deps): various updates
+- chore(deps): various updates
 
 ## [2022-12-30] v2.0.4
 
-* chore(deps): bump github.com/Scalingo/go-handlers from 1.4.4 to 1.6.0
-* chore(deps): bump github.com/Scalingo/go-utils/logger from 1.1.0 to 1.2.0
-* chore(deps): bump github.com/Scalingo/go-philae/v4 from 4.4.5 to 4.4.7
-* chore(deps): bump github.com/gofrs/uuid from 4.2.0+incompatible to 4.3.1+incompatible
-* chore(deps): bump github.com/j-keck/arping from 1.0.2 to 1.0.3
-* chore(deps): bump github.com/urfave/cli from 1.22.9 to 1.22.10
-* chore(deps): bump github.com/sirupsen/logrus from 1.8.1 to 1.9.0
-* chore(deps): bump go.etcd.io/etcd/client/v3 from 3.5.4 to 3.5.6
-* chore(deps): bump go.etcd.io/etcd/api/v3 from 3.5.4 to 3.5.6
-* chore(deps): bump github.com/stretchr/testify from 1.7.1 to 1.8.1
+- chore(deps): bump github.com/Scalingo/go-handlers from 1.4.4 to 1.6.0
+- chore(deps): bump github.com/Scalingo/go-utils/logger from 1.1.0 to 1.2.0
+- chore(deps): bump github.com/Scalingo/go-philae/v4 from 4.4.5 to 4.4.7
+- chore(deps): bump github.com/gofrs/uuid from 4.2.0+incompatible to 4.3.1+incompatible
+- chore(deps): bump github.com/j-keck/arping from 1.0.2 to 1.0.3
+- chore(deps): bump github.com/urfave/cli from 1.22.9 to 1.22.10
+- chore(deps): bump github.com/sirupsen/logrus from 1.8.1 to 1.9.0
+- chore(deps): bump go.etcd.io/etcd/client/v3 from 3.5.4 to 3.5.6
+- chore(deps): bump go.etcd.io/etcd/api/v3 from 3.5.4 to 3.5.6
+- chore(deps): bump github.com/stretchr/testify from 1.7.1 to 1.8.1
 
 ## [2022-06-09] v2.0.3
 
-* chore(go): use go 1.17
-* chore(deps): bump github.com/gofrs/uuid from 4.1.0+incompatible to 4.2.0+incompatible
-* chore(deps): bump go.etcd.io/etcd/api/v3 from 3.5.0 to 3.5.4
-* chore(deps): bump go.etcd.io/etcd/client/v3 from 3.5.0 to 3.5.4
-* chore(deps): bump github.com/Scalingo/go-handlers from 1.4.0 to 1.4.3
-* chore(deps): bump github.com/Scalingo/go-utils/errors from 1.0.0 to 1.1.0
-* chore(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
-* chore(deps): bump github.com/urfave/cli from 1.22.5 to 1.22.9
+- chore(go): use go 1.17
+- chore(deps): bump github.com/gofrs/uuid from 4.1.0+incompatible to 4.2.0+incompatible
+- chore(deps): bump go.etcd.io/etcd/api/v3 from 3.5.0 to 3.5.4
+- chore(deps): bump go.etcd.io/etcd/client/v3 from 3.5.0 to 3.5.4
+- chore(deps): bump github.com/Scalingo/go-handlers from 1.4.0 to 1.4.3
+- chore(deps): bump github.com/Scalingo/go-utils/errors from 1.0.0 to 1.1.0
+- chore(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.1
+- chore(deps): bump github.com/urfave/cli from 1.22.5 to 1.22.9
 
 ## [2021-10-21] v2.0.2
 
-* chore(deps): bump github.com/Scalingo/go-philae/v4 from 4.4.2 to 4.4.3
-* chore(deps): bump github.com/Scalingo/go-utils/logger from 1.0.0 to v1.1.0
+- chore(deps): bump github.com/Scalingo/go-philae/v4 from 4.4.2 to 4.4.3
+- chore(deps): bump github.com/Scalingo/go-utils/logger from 1.0.0 to v1.1.0
 
 ## [2021-08-23] v2.0.1
 
-* chore(deps): bump github.com/olekukonko/tablewriter v0.0.0-20180912035003-be2c049b30cc => v0.0.5
-* chore(deps): replace github.com/satori/go.uuid with github.com/gofrs/uuid
-* chore(deps): update github.com/gofrs/uuid v3.4.0+incompatible => v4.0.0+incompatible
-* chore(deps): update github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56 => v1.0.2
-* chore(deps): update github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e => v3.0.0
-* chore(deps): update github.com/looplab/fsm v0.0.0-20180515091235-f980bdb68a89 => v0.3.0
-* chore(deps): bump go.etcd.io to Go Module version
-* chore(deps): update github.com/Scalingo/go-utils/etcd v1.0.1 => v1.1.0
-* chore: replace Travis CI with GitHub Actions to release new versions
+- chore(deps): bump github.com/olekukonko/tablewriter v0.0.0-20180912035003-be2c049b30cc => v0.0.5
+- chore(deps): replace github.com/satori/go.uuid with github.com/gofrs/uuid
+- chore(deps): update github.com/gofrs/uuid v3.4.0+incompatible => v4.0.0+incompatible
+- chore(deps): update github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56 => v1.0.2
+- chore(deps): update github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e => v3.0.0
+- chore(deps): update github.com/looplab/fsm v0.0.0-20180515091235-f980bdb68a89 => v0.3.0
+- chore(deps): bump go.etcd.io to Go Module version
+- chore(deps): update github.com/Scalingo/go-utils/etcd v1.0.1 => v1.1.0
+- chore: replace Travis CI with GitHub Actions to release new versions
 
 ## [2021-07-30] v2.0.0
 
-* chore(Dependabot): Update various dependencies
-* Bump github.com/sirupsen/logrus from 1.8.0 to 1.8.1
-* Bump github.com/golang/mock from 1.5.0 to 1.6.0
-* Add `/failover` route and `failover` command to force a failover on an ACTIVATED IP.
-* Remove `/try-get-lock` route and `try-get-lock` command in favor of `failover`
-* Destroying an IP is now synchronous
-* Remove `KeepaliveInterval` from the IP model
-* Add a way to update IP healthchecks
-* Bad request body key is `error` instead of `msg`
-* Not found body is `{"resource": "IP", "error" : "not found"}`
+- chore(Dependabot): Update various dependencies
+- Bump github.com/sirupsen/logrus from 1.8.0 to 1.8.1
+- Bump github.com/golang/mock from 1.5.0 to 1.6.0
+- Add `/failover` route and `failover` command to force a failover on an ACTIVATED IP.
+- Remove `/try-get-lock` route and `try-get-lock` command in favor of `failover`
+- Destroying an IP is now synchronous
+- Remove `KeepaliveInterval` from the IP model
+- Add a way to update IP healthchecks
+- Bad request body key is `error` instead of `msg`
+- Not found body is `{"resource": "IP", "error" : "not found"}`
 
 ## [2020-11-20] v1.9.3
 
-* Update deps: use github.com/Scalingo/go-philae/v4@v4.4.2
+- Update deps: use github.com/Scalingo/go-philae/v4@v4.4.2
 
 ## [2020-11-19] v1.9.2
 
-* Update deps: use go.etcd.io/etcd/v3 instead of github.com/coreos/etcd
+- Update deps: use go.etcd.io/etcd/v3 instead of github.com/coreos/etcd
 
 ## [2020-11-19] v1.9.1
 
-* Update deps: github.com/Scalingo/go-utils, use submodules instead of global
+- Update deps: github.com/Scalingo/go-utils, use submodules instead of global
 
 ## [2020-05-06] v1.9.0
 
-* Use a single ETCD lease per server instead of one per IP to reduce load on the etcd cluster
-* Validate the health check port value to be in the range [1:65535]
+- Use a single ETCD lease per server instead of one per IP to reduce load on the etcd cluster
+- Validate the health check port value to be in the range [1:65535]
 
 ## [2020-03-06] v1.8.4
 
-* Fix condition leading to extra lease renewal for short keepalive durations
+- Fix condition leading to extra lease renewal for short keepalive durations
 
 ## [2020-03-06] v1.8.3
 
-* Make LeaseTime according to the IP KeepaliveInterval if set
+- Make LeaseTime according to the IP KeepaliveInterval if set
 
 ## [2020-03-06] v1.8.2
 
-* Update mocks for testing
+- Update mocks for testing
 
 ## [2020-03-06] v1.8.1
 
-* Update api.Client interface
+- Update api.Client interface
 
 ## [2020-03-06] v1.8.0
 
-* Feature: Allow the configuration of KeepaliveInterval and HealthcheckInterval by IP
+- Feature: Allow the configuration of KeepaliveInterval and HealthcheckInterval by IP
 
 ## [2020-01-29] 1.7.1
 
-* Dependencies: Update etcd and go-utils libraries
+- Dependencies: Update etcd and go-utils libraries
 
 ## [2019-12-17] 1.7.0
 
-* Bugfix: when a save leased is no found, consider it expired to renew it completely
-* ARP: Only send 3 Gratuitous ARP packets after becoming primary, configurable with env `ARP_GRATUITOUS_COUNT`
+- Bugfix: when a save leased is no found, consider it expired to renew it completely
+- ARP: Only send 3 Gratuitous ARP packets after becoming primary, configurable with env `ARP_GRATUITOUS_COUNT`
 
 ## [2019-11-08] 1.6.3
 
-* Improve logging less useless errors when un-threatening healthcheck fail
+- Improve logging less useless errors when un-threatening healthcheck fail
 
 ## [2019-11-05] 1.6.2
 
-* Improve logging after retries have been executed in etcd locker/healthcheck
+- Improve logging after retries have been executed in etcd locker/healthcheck
 
 ## [2019-11-05] 1.6.1
 
-* Add retry logics when refreshing ETCD lock (default 5 retries)
-* Reduce logging verbosity when healthcheck is negative
+- Add retry logics when refreshing ETCD lock (default 5 retries)
+- Reduce logging verbosity when healthcheck is negative
 
 ## [2019-10-24] 1.6.0
 
-* Add PPROF web
-* Add BOOTING state to manage boot order.
-* Fix: High CPU consumption when doing gratuitous ARP
-* Fix: Do not remove IP on restart
+- Add PPROF web
+- Add BOOTING state to manage boot order.
+- Fix: High CPU consumption when doing gratuitous ARP
+- Fix: Do not remove IP on restart
 
 ## [2019-08-12] 1.5.2
 
-* Fix: Logging is too verbose
+- Fix: Logging is too verbose
 
 ## [2019-08-12] 1.5.1
 
-* Do not loose IP on restart
+- Do not loose IP on restart
 
 ## [2019-08-12] 1.5.0
 
-* Release IP on standby
-* Change LeaseDuration to 5 * KeepAliveInterval
+- Release IP on standby
+- Change LeaseDuration to 5 \* KeepAliveInterval
 
 ## [2019-07-18] 1.4.3
 
-* Update: logrus-rollbar to v1.3.1
+- Update: logrus-rollbar to v1.3.1
 
 ## [2019-07-18] 1.4.2
 
-* Fix: Health checker were stopped too early
+- Fix: Health checker were stopped too early
 
 ## [2019-05-17] 1.4.1
 
-* Fix regression: Remove IP on Stop
+- Fix regression: Remove IP on Stop
 
 ## [2019-05-15] 1.4.0
 
-* Do not release IP on standby
-* Do not use another lease if it has not expired
+- Do not release IP on standby
+- Do not use another lease if it has not expired
 
 ## [2019-05-14] 1.3.4
 
-* Lease time is now 3 times the KeepaliveInterval
+- Lease time is now 3 times the KeepaliveInterval
 
 ## [2019-05-03] 1.3.3
 
-* Update go-philae to v4.3.2
+- Update go-philae to v4.3.2
 
 ## [2019-05-03] 1.3.2
 
-* Update go-philae to v4.3.1
-* Use go modules instead of dep
+- Update go-philae to v4.3.1
+- Use go modules instead of dep
 
 ## [2019-04-30] 1.3.1
 
-* Update go-philae to v4.3.0
+- Update go-philae to v4.3.0
 
 ## [2019-04-25] 1.3.0
 
-* Do not fail on first healthcheck failure, add `FAIL_COUNT_BEFORE_FAILOVER`
+- Do not fail on first healthcheck failure, add `FAIL_COUNT_BEFORE_FAILOVER`
   environment variable to configure the number of healthcheck failure before
   failover.
 
 ## [2019-04-15] 1.2.0
 
-* Fix Client interface
-* Make probes more verbose
+- Fix Client interface
+- Make probes more verbose
 
 ## [2018-12-10] 1.1.0
 
-* Release IP early if someone else got the lock
-* Add the `version` endpoint and command
+- Release IP early if someone else got the lock
+- Add the `version` endpoint and command
 
 ## [2018-11-29] 1.0.0
 
-* First stable release
+- First stable release

--- a/api/apimock/client_mock.go
+++ b/api/apimock/client_mock.go
@@ -8,9 +8,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	api "github.com/Scalingo/link/v2/api"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockClient is a mock of Client interface.
@@ -36,19 +35,19 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// AddIP mocks base method.
-func (m *MockClient) AddIP(arg0 context.Context, arg1 string, arg2 api.AddIPParams) (api.IP, error) {
+// AddEndpoint mocks base method.
+func (m *MockClient) AddEndpoint(arg0 context.Context, arg1 api.AddEndpointParams) (api.Endpoint, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddIP", arg0, arg1, arg2)
-	ret0, _ := ret[0].(api.IP)
+	ret := m.ctrl.Call(m, "AddEndpoint", arg0, arg1)
+	ret0, _ := ret[0].(api.Endpoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// AddIP indicates an expected call of AddIP.
-func (mr *MockClientMockRecorder) AddIP(arg0, arg1, arg2 interface{}) *gomock.Call {
+// AddEndpoint indicates an expected call of AddEndpoint.
+func (mr *MockClientMockRecorder) AddEndpoint(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddIP", reflect.TypeOf((*MockClient)(nil).AddIP), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEndpoint", reflect.TypeOf((*MockClient)(nil).AddEndpoint), arg0, arg1)
 }
 
 // Failover mocks base method.
@@ -65,63 +64,63 @@ func (mr *MockClientMockRecorder) Failover(arg0, arg1 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Failover", reflect.TypeOf((*MockClient)(nil).Failover), arg0, arg1)
 }
 
-// GetIP mocks base method.
-func (m *MockClient) GetIP(arg0 context.Context, arg1 string) (api.IP, error) {
+// GetEndpoint mocks base method.
+func (m *MockClient) GetEndpoint(arg0 context.Context, arg1 string) (api.Endpoint, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIP", arg0, arg1)
-	ret0, _ := ret[0].(api.IP)
+	ret := m.ctrl.Call(m, "GetEndpoint", arg0, arg1)
+	ret0, _ := ret[0].(api.Endpoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetIP indicates an expected call of GetIP.
-func (mr *MockClientMockRecorder) GetIP(arg0, arg1 interface{}) *gomock.Call {
+// GetEndpoint indicates an expected call of GetEndpoint.
+func (mr *MockClientMockRecorder) GetEndpoint(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIP", reflect.TypeOf((*MockClient)(nil).GetIP), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEndpoint", reflect.TypeOf((*MockClient)(nil).GetEndpoint), arg0, arg1)
 }
 
-// ListIPs mocks base method.
-func (m *MockClient) ListIPs(arg0 context.Context) ([]api.IP, error) {
+// ListEndpoints mocks base method.
+func (m *MockClient) ListEndpoints(arg0 context.Context) ([]api.Endpoint, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListIPs", arg0)
-	ret0, _ := ret[0].([]api.IP)
+	ret := m.ctrl.Call(m, "ListEndpoints", arg0)
+	ret0, _ := ret[0].([]api.Endpoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ListIPs indicates an expected call of ListIPs.
-func (mr *MockClientMockRecorder) ListIPs(arg0 interface{}) *gomock.Call {
+// ListEndpoints indicates an expected call of ListEndpoints.
+func (mr *MockClientMockRecorder) ListEndpoints(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIPs", reflect.TypeOf((*MockClient)(nil).ListIPs), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEndpoints", reflect.TypeOf((*MockClient)(nil).ListEndpoints), arg0)
 }
 
-// RemoveIP mocks base method.
-func (m *MockClient) RemoveIP(arg0 context.Context, arg1 string) error {
+// RemoveEndpoint mocks base method.
+func (m *MockClient) RemoveEndpoint(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveIP", arg0, arg1)
+	ret := m.ctrl.Call(m, "RemoveEndpoint", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RemoveIP indicates an expected call of RemoveIP.
-func (mr *MockClientMockRecorder) RemoveIP(arg0, arg1 interface{}) *gomock.Call {
+// RemoveEndpoint indicates an expected call of RemoveEndpoint.
+func (mr *MockClientMockRecorder) RemoveEndpoint(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveIP", reflect.TypeOf((*MockClient)(nil).RemoveIP), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveEndpoint", reflect.TypeOf((*MockClient)(nil).RemoveEndpoint), arg0, arg1)
 }
 
-// UpdateIP mocks base method.
-func (m *MockClient) UpdateIP(arg0 context.Context, arg1 string, arg2 api.UpdateIPParams) (api.IP, error) {
+// UpdateEndpoint mocks base method.
+func (m *MockClient) UpdateEndpoint(arg0 context.Context, arg1 string, arg2 api.UpdateEndpointParams) (api.Endpoint, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateIP", arg0, arg1, arg2)
-	ret0, _ := ret[0].(api.IP)
+	ret := m.ctrl.Call(m, "UpdateEndpoint", arg0, arg1, arg2)
+	ret0, _ := ret[0].(api.Endpoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UpdateIP indicates an expected call of UpdateIP.
-func (mr *MockClientMockRecorder) UpdateIP(arg0, arg1, arg2 interface{}) *gomock.Call {
+// UpdateEndpoint indicates an expected call of UpdateEndpoint.
+func (mr *MockClientMockRecorder) UpdateEndpoint(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIP", reflect.TypeOf((*MockClient)(nil).UpdateIP), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEndpoint", reflect.TypeOf((*MockClient)(nil).UpdateEndpoint), arg0, arg1, arg2)
 }
 
 // Version mocks base method.

--- a/api/client.go
+++ b/api/client.go
@@ -5,11 +5,11 @@ import (
 )
 
 type Client interface {
-	ListIPs(context.Context) ([]IP, error)
-	GetIP(ctx context.Context, id string) (IP, error)
-	AddIP(ctx context.Context, ip string, params AddIPParams) (IP, error)
-	UpdateIP(ctx context.Context, id string, params UpdateIPParams) (IP, error)
-	RemoveIP(ctx context.Context, id string) error
+	ListEndpoints(context.Context) ([]Endpoint, error)
+	GetEndpoint(ctx context.Context, id string) (Endpoint, error)
+	AddEndpoint(ctx context.Context, params AddEndpointParams) (Endpoint, error)
+	UpdateEndpoint(ctx context.Context, id string, params UpdateEndpointParams) (Endpoint, error)
+	RemoveEndpoint(ctx context.Context, id string) error
 	Failover(ctx context.Context, id string) error
 	Version(context.Context) (string, error)
 }

--- a/api/http_client.go
+++ b/api/http_client.go
@@ -4,14 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
 
-	"github.com/Scalingo/link/v2/models"
+	"github.com/Scalingo/go-utils/errors/v2"
 )
+
+var _ Client = HTTPClient{}
 
 type HTTPClient struct {
 	url      string
@@ -58,7 +59,7 @@ func WithTimeout(timeout time.Duration) ClientOpt {
 }
 
 func (c HTTPClient) Version(ctx context.Context) (string, error) {
-	req, err := c.getRequest(http.MethodGet, "/version", nil)
+	req, err := c.getRequest(ctx, http.MethodGet, "/version", nil)
 	if err != nil {
 		return "", err
 	}
@@ -68,7 +69,7 @@ func (c HTTPClient) Version(ctx context.Context) (string, error) {
 		return "", err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return "", getErrorFromBody(resp.StatusCode, resp.Body)
+		return "", getErrorFromBody(ctx, resp.StatusCode, resp.Body)
 	}
 
 	var res map[string]string
@@ -79,161 +80,154 @@ func (c HTTPClient) Version(ctx context.Context) (string, error) {
 	return res["version"], nil
 }
 
-func (c HTTPClient) ListIPs(ctx context.Context) ([]IP, error) {
-	req, err := c.getRequest(http.MethodGet, "/ips", nil)
+func (c HTTPClient) ListEndpoints(ctx context.Context) ([]Endpoint, error) {
+	req, err := c.getRequest(ctx, http.MethodGet, "/ips", nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(ctx, err, "create request")
 	}
 
 	resp, err := c.getClient().Do(req)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(ctx, err, "do request")
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, getErrorFromBody(resp.StatusCode, resp.Body)
+		return nil, getErrorFromBody(ctx, resp.StatusCode, resp.Body)
 	}
 
-	var res map[string][]IP
+	res := EndpointListResponse{}
 
 	err = json.NewDecoder(resp.Body).Decode(&res)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(ctx, err, "read endpoints JSON")
 	}
 
-	return res["ips"], nil
+	return res.Endpoints, nil
 }
 
-func (c HTTPClient) GetIP(ctx context.Context, id string) (IP, error) {
-	req, err := c.getRequest(http.MethodGet, fmt.Sprintf("/ips/%s", id), nil)
+func (c HTTPClient) GetEndpoint(ctx context.Context, id string) (Endpoint, error) {
+	req, err := c.getRequest(ctx, http.MethodGet, fmt.Sprintf("/ips/%s", id), nil)
 	if err != nil {
-		return IP{}, err
+		return Endpoint{}, errors.Wrap(ctx, err, "create request")
 	}
 
 	resp, err := c.getClient().Do(req)
 	if err != nil {
-		return IP{}, err
+		return Endpoint{}, errors.Wrap(ctx, err, "do request")
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return IP{}, getErrorFromBody(resp.StatusCode, resp.Body)
+		return Endpoint{}, getErrorFromBody(ctx, resp.StatusCode, resp.Body)
 	}
 
-	var res map[string]IP
+	res := EndpointGetResponse{}
 
 	err = json.NewDecoder(resp.Body).Decode(&res)
 	if err != nil {
-		return IP{}, err
+		return Endpoint{}, errors.Wrap(ctx, err, "read endpoint JSON")
 	}
 
-	return res["ip"], nil
+	return res.Endpoint, nil
 }
 
 func (c HTTPClient) Failover(ctx context.Context, id string) error {
-	req, err := c.getRequest(http.MethodPost, fmt.Sprintf("/ips/%s/failover", id), nil)
+	req, err := c.getRequest(ctx, http.MethodPost, fmt.Sprintf("/ips/%s/failover", id), nil)
 	if err != nil {
 		return err
 	}
 
 	resp, err := c.getClient().Do(req)
 	if err != nil {
-		return err
+		return errors.Wrap(ctx, err, "do request")
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		return getErrorFromBody(resp.StatusCode, resp.Body)
+		return getErrorFromBody(ctx, resp.StatusCode, resp.Body)
 	}
 
 	return nil
 }
 
-type AddIPParams struct {
-	HealthcheckInterval int                  `json:"healthcheck_interval"`
-	Checks              []models.Healthcheck `json:"checks"`
+type AddEndpointParams struct {
+	HealthCheckInterval int           `json:"healthcheck_interval"`
+	Checks              []HealthCheck `json:"checks"`
+	IP                  string        `json:"ip"`
 }
 
-func (c HTTPClient) AddIP(ctx context.Context, ip string, params AddIPParams) (IP, error) {
+func (c HTTPClient) AddEndpoint(ctx context.Context, params AddEndpointParams) (Endpoint, error) {
 	buffer := &bytes.Buffer{}
-	err := json.NewEncoder(buffer).Encode(models.IP{
-		IP:                  ip,
-		HealthcheckInterval: params.HealthcheckInterval,
-		Checks:              params.Checks,
-	})
+	err := json.NewEncoder(buffer).Encode(params)
 	if err != nil {
-		return IP{}, err
+		return Endpoint{}, errors.Wrap(ctx, err, "encode endpoint")
 	}
 
-	req, err := c.getRequest(http.MethodPost, "/ips", buffer)
+	req, err := c.getRequest(ctx, http.MethodPost, "/ips", buffer)
 	if err != nil {
-		return IP{}, err
+		return Endpoint{}, errors.Wrap(ctx, err, "create request")
 	}
 
 	resp, err := c.getClient().Do(req)
 	if err != nil {
-		return IP{}, err
+		return Endpoint{}, errors.Wrap(ctx, err, "do request")
 	}
 
-	if resp.StatusCode != http.StatusCreated {
-		return IP{}, getErrorFromBody(resp.StatusCode, resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return Endpoint{}, getErrorFromBody(ctx, resp.StatusCode, resp.Body)
 	}
 
-	var res IP
+	res := Endpoint{}
 
 	err = json.NewDecoder(resp.Body).Decode(&res)
 	if err != nil {
-		return IP{}, err
+		return Endpoint{}, errors.Wrap(ctx, err, "read endpoint JSON")
 	}
 
 	return res, nil
 }
 
-type UpdateIPParams struct {
-	Healthchecks []models.Healthcheck `json:"healthchecks"`
-}
-
-func (c HTTPClient) UpdateIP(ctx context.Context, id string, params UpdateIPParams) (IP, error) {
+func (c HTTPClient) UpdateEndpoint(ctx context.Context, id string, params UpdateEndpointParams) (Endpoint, error) {
 	buffer := &bytes.Buffer{}
 	err := json.NewEncoder(buffer).Encode(params)
 	if err != nil {
-		return IP{}, err
+		return Endpoint{}, errors.Wrap(ctx, err, "encode endpoint")
 	}
 
-	req, err := c.getRequest(http.MethodPatch, fmt.Sprintf("/ips/%s", id), buffer)
+	req, err := c.getRequest(ctx, http.MethodPatch, fmt.Sprintf("/ips/%s", id), buffer)
 	if err != nil {
-		return IP{}, err
+		return Endpoint{}, errors.Wrap(ctx, err, "create request")
 	}
 
 	resp, err := c.getClient().Do(req)
 	if err != nil {
-		return IP{}, err
+		return Endpoint{}, errors.Wrap(ctx, err, "do request")
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return IP{}, getErrorFromBody(resp.StatusCode, resp.Body)
+		return Endpoint{}, getErrorFromBody(ctx, resp.StatusCode, resp.Body)
 	}
 
-	var ip IP
+	var ip Endpoint
 	err = json.NewDecoder(resp.Body).Decode(&ip)
 	if err != nil {
-		return IP{}, err
+		return Endpoint{}, errors.Wrap(ctx, err, "read endpoint JSON")
 	}
 
 	return ip, nil
 }
 
-func (c HTTPClient) RemoveIP(ctx context.Context, id string) error {
-	req, err := c.getRequest(http.MethodDelete, fmt.Sprintf("/ips/%s", id), nil)
+func (c HTTPClient) RemoveEndpoint(ctx context.Context, id string) error {
+	req, err := c.getRequest(ctx, http.MethodDelete, fmt.Sprintf("/ips/%s", id), nil)
 	if err != nil {
-		return err
+		return errors.Wrap(ctx, err, "create request")
 	}
 
 	resp, err := c.getClient().Do(req)
 	if err != nil {
-		return err
+		return errors.Wrap(ctx, err, "do request")
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		return getErrorFromBody(resp.StatusCode, resp.Body)
+		return getErrorFromBody(ctx, resp.StatusCode, resp.Body)
 	}
 
 	return nil
@@ -245,7 +239,7 @@ func (c HTTPClient) getClient() *http.Client {
 	}
 }
 
-func (c HTTPClient) getRequest(method, path string, body io.Reader) (*http.Request, error) {
+func (c HTTPClient) getRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
 	var url string
 	if path[0] != '/' {
 		path = "/" + path
@@ -254,7 +248,7 @@ func (c HTTPClient) getRequest(method, path string, body io.Reader) (*http.Reque
 
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(ctx, err, "create request")
 	}
 
 	if c.username != "" || c.password != "" {
@@ -264,7 +258,7 @@ func (c HTTPClient) getRequest(method, path string, body io.Reader) (*http.Reque
 	return req, nil
 }
 
-func getErrorFromBody(statusCode int, body io.Reader) error {
+func getErrorFromBody(ctx context.Context, statusCode int, body io.Reader) error {
 	if statusCode/100 == 5 || statusCode/100 == 4 {
 		var res map[string]interface{}
 		err := json.NewDecoder(body).Decode(&res)
@@ -281,7 +275,7 @@ func getErrorFromBody(statusCode int, body io.Reader) error {
 		case 404:
 			return ErrNotFound{value}
 		default:
-			return errors.New(value)
+			return errors.New(ctx, value)
 		}
 	}
 

--- a/api/types.go
+++ b/api/types.go
@@ -1,14 +1,40 @@
 package api
 
-import "github.com/Scalingo/link/v2/models"
-
 const (
 	Activated = "ACTIVATED"
 	Standby   = "STANDBY"
 	Failing   = "FAILING"
 )
 
-type IP struct {
-	models.IP
-	Status string `json:"status,omitempty"`
+type Endpoint struct {
+	ID string `json:"id"`
+
+	IP                  string        `json:"ip"`
+	Status              string        `json:"status,omitempty"`
+	Checks              []HealthCheck `json:"checks,omitempty"`
+	HealthCheckInterval int           `json:"healthcheck_interval"`
+}
+
+type HealthCheckType string
+
+const (
+	TCPHealthCheck HealthCheckType = "TCP"
+)
+
+type HealthCheck struct {
+	Type HealthCheckType `json:"type"`
+	Host string          `json:"host"`
+	Port int             `json:"port"`
+}
+
+type EndpointGetResponse struct {
+	Endpoint Endpoint `json:"ip"`
+}
+
+type EndpointListResponse struct {
+	Endpoints []Endpoint `json:"ips"`
+}
+
+type UpdateEndpointParams struct {
+	HealthChecks []HealthCheck `json:"healthchecks"`
 }

--- a/cmd/link-client/formatter.go
+++ b/cmd/link-client/formatter.go
@@ -13,25 +13,25 @@ import (
 	"github.com/Scalingo/link/v2/api"
 )
 
-func formatIPs(ips []api.IP) {
+func formatEndpoints(endpoints []api.Endpoint) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"ID", "IP", "Status", "CHECKS"})
 
-	for _, ip := range ips {
-		status := formatStatus(ip)
+	for _, endpoint := range endpoints {
+		status := formatStatus(endpoint)
 
 		checks := "None"
-		if len(ip.Checks) > 0 {
+		if len(endpoint.Checks) > 0 {
 			var c []string
-			for _, check := range ip.IP.Checks {
+			for _, check := range endpoint.Checks {
 				c = append(c, fmt.Sprintf("%s - %s", check.Type, net.JoinHostPort(check.Host, strconv.Itoa(check.Port))))
 			}
 
 			checks = strings.Join(c, ",")
 		}
 		table.Append([]string{
-			ip.ID,
-			ip.IP.IP,
+			endpoint.ID,
+			endpoint.IP,
 			status,
 			checks,
 		})
@@ -39,7 +39,7 @@ func formatIPs(ips []api.IP) {
 	table.Render()
 }
 
-func formatIP(ip api.IP) {
+func formatEndpoint(ip api.Endpoint) {
 	fmt.Printf("ID:\t%s\n", ip.ID)
 	fmt.Printf("Status:\t%s\n", formatStatus(ip))
 	if len(ip.Checks) == 0 {
@@ -52,8 +52,8 @@ func formatIP(ip api.IP) {
 	}
 }
 
-func formatStatus(ip api.IP) string {
-	switch ip.Status {
+func formatStatus(endpoint api.Endpoint) string {
+	switch endpoint.Status {
 	case api.Activated:
 		return aurora.Green("ACTIVATED").String()
 	case api.Standby:
@@ -61,6 +61,6 @@ func formatStatus(ip api.IP) string {
 	case api.Failing:
 		return aurora.Red("FAILING").String()
 	default:
-		return ip.Status
+		return endpoint.Status
 	}
 }

--- a/etcdmock/lease_mock.go
+++ b/etcdmock/lease_mock.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v3 "go.etcd.io/etcd/client/v3"
+	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 // MockLease is a mock of Lease interface.
@@ -50,10 +50,10 @@ func (mr *MockLeaseMockRecorder) Close() *gomock.Call {
 }
 
 // Grant mocks base method.
-func (m *MockLease) Grant(arg0 context.Context, arg1 int64) (*v3.LeaseGrantResponse, error) {
+func (m *MockLease) Grant(arg0 context.Context, arg1 int64) (*clientv3.LeaseGrantResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Grant", arg0, arg1)
-	ret0, _ := ret[0].(*v3.LeaseGrantResponse)
+	ret0, _ := ret[0].(*clientv3.LeaseGrantResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -65,10 +65,10 @@ func (mr *MockLeaseMockRecorder) Grant(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // KeepAlive mocks base method.
-func (m *MockLease) KeepAlive(arg0 context.Context, arg1 v3.LeaseID) (<-chan *v3.LeaseKeepAliveResponse, error) {
+func (m *MockLease) KeepAlive(arg0 context.Context, arg1 clientv3.LeaseID) (<-chan *clientv3.LeaseKeepAliveResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KeepAlive", arg0, arg1)
-	ret0, _ := ret[0].(<-chan *v3.LeaseKeepAliveResponse)
+	ret0, _ := ret[0].(<-chan *clientv3.LeaseKeepAliveResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -80,10 +80,10 @@ func (mr *MockLeaseMockRecorder) KeepAlive(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // KeepAliveOnce mocks base method.
-func (m *MockLease) KeepAliveOnce(arg0 context.Context, arg1 v3.LeaseID) (*v3.LeaseKeepAliveResponse, error) {
+func (m *MockLease) KeepAliveOnce(arg0 context.Context, arg1 clientv3.LeaseID) (*clientv3.LeaseKeepAliveResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "KeepAliveOnce", arg0, arg1)
-	ret0, _ := ret[0].(*v3.LeaseKeepAliveResponse)
+	ret0, _ := ret[0].(*clientv3.LeaseKeepAliveResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -95,10 +95,10 @@ func (mr *MockLeaseMockRecorder) KeepAliveOnce(arg0, arg1 interface{}) *gomock.C
 }
 
 // Leases mocks base method.
-func (m *MockLease) Leases(arg0 context.Context) (*v3.LeaseLeasesResponse, error) {
+func (m *MockLease) Leases(arg0 context.Context) (*clientv3.LeaseLeasesResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Leases", arg0)
-	ret0, _ := ret[0].(*v3.LeaseLeasesResponse)
+	ret0, _ := ret[0].(*clientv3.LeaseLeasesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -110,10 +110,10 @@ func (mr *MockLeaseMockRecorder) Leases(arg0 interface{}) *gomock.Call {
 }
 
 // Revoke mocks base method.
-func (m *MockLease) Revoke(arg0 context.Context, arg1 v3.LeaseID) (*v3.LeaseRevokeResponse, error) {
+func (m *MockLease) Revoke(arg0 context.Context, arg1 clientv3.LeaseID) (*clientv3.LeaseRevokeResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Revoke", arg0, arg1)
-	ret0, _ := ret[0].(*v3.LeaseRevokeResponse)
+	ret0, _ := ret[0].(*clientv3.LeaseRevokeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -125,14 +125,14 @@ func (mr *MockLeaseMockRecorder) Revoke(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // TimeToLive mocks base method.
-func (m *MockLease) TimeToLive(arg0 context.Context, arg1 v3.LeaseID, arg2 ...v3.LeaseOption) (*v3.LeaseTimeToLiveResponse, error) {
+func (m *MockLease) TimeToLive(arg0 context.Context, arg1 clientv3.LeaseID, arg2 ...clientv3.LeaseOption) (*clientv3.LeaseTimeToLiveResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "TimeToLive", varargs...)
-	ret0, _ := ret[0].(*v3.LeaseTimeToLiveResponse)
+	ret0, _ := ret[0].(*clientv3.LeaseTimeToLiveResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Scalingo/go-handlers v1.8.2
 	github.com/Scalingo/go-philae/v4 v4.4.7
 	github.com/Scalingo/go-utils/errors v1.1.1
+	github.com/Scalingo/go-utils/errors/v2 v2.4.0
 	github.com/Scalingo/go-utils/etcd v1.1.2
 	github.com/Scalingo/go-utils/logger v1.4.0
 	github.com/Scalingo/go-utils/retry v1.1.1
@@ -29,7 +30,6 @@ require (
 require (
 	github.com/Scalingo/errgo-rollbar v0.2.1 // indirect
 	github.com/Scalingo/go-utils/crypto v1.0.0 // indirect
-	github.com/Scalingo/go-utils/errors/v2 v2.4.0 // indirect
 	github.com/Scalingo/go-utils/security v1.0.0 // indirect
 	github.com/Scalingo/logrus-rollbar v1.4.2 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect

--- a/healthcheck/checker.go
+++ b/healthcheck/checker.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Scalingo/go-philae/v4/prober"
 	"github.com/Scalingo/go-philae/v4/tcpprobe"
+	"github.com/Scalingo/link/v2/api"
 	"github.com/Scalingo/link/v2/config"
 	"github.com/Scalingo/link/v2/models"
 )
@@ -17,11 +18,11 @@ type checker struct {
 	prober *prober.Prober
 }
 
-func FromChecks(cfg config.Config, checks []models.Healthcheck) checker {
+func FromChecks(cfg config.Config, checks []models.HealthCheck) checker {
 	prober := prober.NewProber()
 	for _, check := range checks {
 		switch check.Type {
-		case models.TCPHealthCheck:
+		case api.TCPHealthCheck:
 			prober.AddProbe(tcpprobe.NewTCPProbe("tcp", check.Addr(), tcpprobe.TCPOptions{
 				Timeout: cfg.HealthcheckTimeout,
 			}))

--- a/healthcheck/cheker_test.go
+++ b/healthcheck/cheker_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Scalingo/go-philae/v4/prober"
 	"github.com/Scalingo/go-philae/v4/sampleprobe"
+	"github.com/Scalingo/link/v2/api"
 	"github.com/Scalingo/link/v2/config"
 	"github.com/Scalingo/link/v2/models"
 )
@@ -17,18 +18,18 @@ import (
 func TestFromChecks(t *testing.T) {
 	examples := []struct {
 		Name           string
-		Checks         []models.Healthcheck
+		Checks         []models.HealthCheck
 		ExpectedChecks []string
 	}{
 		{
 			Name:           "With no checks",
-			Checks:         []models.Healthcheck{},
+			Checks:         []models.HealthCheck{},
 			ExpectedChecks: []string{},
 		}, {
 			Name: "With a tcp check",
-			Checks: []models.Healthcheck{
+			Checks: []models.HealthCheck{
 				{
-					Type: models.TCPHealthCheck,
+					Type: api.TCPHealthCheck,
 				},
 			},
 			ExpectedChecks: []string{"tcp"},

--- a/ip/event_manager.go
+++ b/ip/event_manager.go
@@ -27,7 +27,7 @@ func (m *manager) Stop(ctx context.Context) error {
 	ctx = logger.ToCtx(ctx, log)
 
 	log.Info("Stops the IP manager")
-	hosts, err := m.storage.GetIPHosts(ctx, m.IP())
+	hosts, err := m.storage.GetEndpointHosts(ctx, m.Endpoint())
 	if err != nil {
 		return errors.Wrap(err, "fail to get new hosts")
 	}
@@ -60,7 +60,7 @@ func (m *manager) Stop(ctx context.Context) error {
 	}
 
 	log.Info("Unlink IP from the host")
-	err = m.storage.UnlinkIPFromCurrentHost(ctx, m.ip)
+	err = m.storage.UnlinkEndpointFromCurrentHost(ctx, m.endpoint)
 	if err != nil {
 		return errors.Wrap(err, "fail to unlink IP")
 	}

--- a/ip/event_manager_test.go
+++ b/ip/event_manager_test.go
@@ -179,13 +179,13 @@ func TestManager_Stop(t *testing.T) {
 			networkMock := networkmock.NewMockNetworkInterface(ctrl)
 
 			hosts := make([]string, example.HostCount)
-			storageMock.EXPECT().GetIPHosts(gomock.Any(), gomock.Any()).Return(hosts, nil)
+			storageMock.EXPECT().GetEndpointHosts(gomock.Any(), gomock.Any()).Return(hosts, nil)
 			if example.Locker != nil {
 				example.Locker(lockerMock)
 			}
 			watcherMock.EXPECT().Stop(gomock.Any()).Return(nil)
 			lockerMock.EXPECT().Stop(gomock.Any()).Return(nil)
-			storageMock.EXPECT().UnlinkIPFromCurrentHost(gomock.Any(), gomock.Any()).Return(nil)
+			storageMock.EXPECT().UnlinkEndpointFromCurrentHost(gomock.Any(), gomock.Any()).Return(nil)
 			eventChan := make(chan string, 2)
 			events := make([]string, 0)
 

--- a/ip/failover.go
+++ b/ip/failover.go
@@ -67,7 +67,7 @@ func (m *manager) Failover(ctx context.Context) error {
 	if !isMaster {
 		return ErrIsNotMaster
 	}
-	hosts, err := m.storage.GetIPHosts(ctx, m.IP())
+	hosts, err := m.storage.GetEndpointHosts(ctx, m.Endpoint())
 	if err != nil {
 		return errors.Wrap(err, "fail to list other nodes listening for this IP")
 	}
@@ -82,7 +82,7 @@ func (m *manager) Failover(ctx context.Context) error {
 	}
 
 	// Update the IP link that will trigger every other watchers on this IP
-	err = m.storage.LinkIPWithCurrentHost(ctx, m.IP())
+	err = m.storage.LinkEndpointWithCurrentHost(ctx, m.Endpoint())
 	if err != nil {
 		return errors.Wrap(err, "fail to update the IP Link")
 	}

--- a/ip/healthchecks.go
+++ b/ip/healthchecks.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (m *manager) healthChecker(ctx context.Context) {
-	interval := time.Duration(m.IP().HealthcheckInterval) * time.Second
+	interval := time.Duration(m.Endpoint().HealthCheckInterval) * time.Second
 	if interval == 0 {
 		interval = m.config.HealthcheckInterval
 	}
@@ -24,30 +24,30 @@ func (m *manager) healthChecker(ctx context.Context) {
 			return
 		}
 
-		m.sendHealthcheckResults(ctx, healthy, err)
+		m.sendHealthCheckResults(ctx, healthy, err)
 
 		time.Sleep(interval)
 	}
 }
 
-func (m *manager) sendHealthcheckResults(ctx context.Context, healthy bool, err error) {
+func (m *manager) sendHealthCheckResults(ctx context.Context, healthy bool, err error) {
 	log := logger.Get(ctx)
 	if healthy {
-		if m.healthcheckFailingCount > 0 {
-			log.Infof("Healthcheck healthy after %v retries", m.healthcheckFailingCount)
-			m.healthcheckFailingCount = 0
+		if m.healthCheckFailingCount > 0 {
+			log.Infof("Healthcheck healthy after %v retries", m.healthCheckFailingCount)
+			m.healthCheckFailingCount = 0
 		}
 		m.sendEvent(HealthCheckSuccessEvent)
 		return
 	}
 
-	m.healthcheckFailingCount++
-	if m.healthcheckFailingCount < m.config.FailCountBeforeFailover {
-		log.WithField("failing_count", m.healthcheckFailingCount).WithError(err).Info("Healthcheck failed (will be retried)")
+	m.healthCheckFailingCount++
+	if m.healthCheckFailingCount < m.config.FailCountBeforeFailover {
+		log.WithField("failing_count", m.healthCheckFailingCount).WithError(err).Info("Healthcheck failed (will be retried)")
 		return
 	}
 
-	if m.healthcheckFailingCount == m.config.FailCountBeforeFailover {
+	if m.healthCheckFailingCount == m.config.FailCountBeforeFailover {
 		log.WithError(err).Error("Healthcheck failed")
 	}
 

--- a/ip/network.go
+++ b/ip/network.go
@@ -14,7 +14,7 @@ import (
 func (m *manager) setActivated(ctx context.Context, _ *fsm.Event) {
 	log := logger.Get(ctx)
 	log.Info("New state: ACTIVATED")
-	err := m.networkInterface.EnsureIP(m.ip.IP)
+	err := m.networkInterface.EnsureIP(m.endpoint.IP)
 	if err != nil {
 		log.WithError(err).Error("Fail to activate IP")
 	}
@@ -23,7 +23,7 @@ func (m *manager) setActivated(ctx context.Context, _ *fsm.Event) {
 func (m *manager) setStandBy(ctx context.Context, _ *fsm.Event) {
 	log := logger.Get(ctx)
 	log.Info("New state: STANDBY")
-	err := m.networkInterface.RemoveIP(m.ip.IP)
+	err := m.networkInterface.RemoveIP(m.endpoint.IP)
 	if err != nil {
 		log.WithError(err).Error("Fail to de-activate IP")
 	}
@@ -33,7 +33,7 @@ func (m *manager) setFailing(ctx context.Context, _ *fsm.Event) {
 	log := logger.Get(ctx)
 	log.Info("New state: FAILING")
 
-	err := m.networkInterface.RemoveIP(m.ip.IP)
+	err := m.networkInterface.RemoveIP(m.endpoint.IP)
 	if err != nil {
 		log.WithError(err).Error("Fail to de-activate IP")
 	}
@@ -58,7 +58,7 @@ func (m *manager) startArpEnsure(ctx context.Context) {
 
 		if currentState == ACTIVATED && garpCount < m.config.ARPGratuitousCount {
 			log.Debug("Send gratuitous ARP request")
-			err := m.networkInterface.EnsureIP(m.ip.IP)
+			err := m.networkInterface.EnsureIP(m.endpoint.IP)
 			if err != nil {
 				log.WithError(err).Error("Fail to ensure IP")
 			} else {

--- a/ip/network_test.go
+++ b/ip/network_test.go
@@ -21,7 +21,7 @@ func TestSetActivated(t *testing.T) {
 
 		networkMock := networkmock.NewMockNetworkInterface(ctrl)
 
-		ip := models.IP{
+		ip := models.Endpoint{
 			IP: "10.0.0.1/32",
 			ID: "test-1234",
 		}
@@ -29,7 +29,7 @@ func TestSetActivated(t *testing.T) {
 
 		manager := &manager{
 			networkInterface: networkMock,
-			ip:               ip,
+			endpoint:         ip,
 		}
 
 		manager.setActivated(context.Background(), &fsm.Event{})
@@ -41,7 +41,7 @@ func TestSetStandBy(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		ip := models.IP{
+		ip := models.Endpoint{
 			IP: "10.0.0.1/32",
 			ID: "test-1234",
 		}
@@ -51,7 +51,7 @@ func TestSetStandBy(t *testing.T) {
 
 		manager := &manager{
 			networkInterface: networkMock,
-			ip:               ip,
+			endpoint:         ip,
 		}
 
 		manager.setStandBy(context.Background(), &fsm.Event{})
@@ -66,7 +66,7 @@ func TestSetFailing(t *testing.T) {
 		networkMock := networkmock.NewMockNetworkInterface(ctrl)
 		lockerMock := lockermock.NewMockLocker(ctrl)
 
-		ip := models.IP{
+		ip := models.Endpoint{
 			IP: "10.0.0.1/32",
 			ID: "test-1234",
 		}
@@ -76,7 +76,7 @@ func TestSetFailing(t *testing.T) {
 		manager := &manager{
 			networkInterface: networkMock,
 			locker:           lockerMock,
-			ip:               ip,
+			endpoint:         ip,
 		}
 
 		manager.setFailing(context.Background(), &fsm.Event{})
@@ -84,7 +84,7 @@ func TestSetFailing(t *testing.T) {
 }
 
 func TestStartARPEnsure(t *testing.T) {
-	ip := models.IP{
+	ip := models.Endpoint{
 		IP: "10.0.0.1/32",
 		ID: "test-1234",
 	}
@@ -109,7 +109,7 @@ func TestStartARPEnsure(t *testing.T) {
 			networkInterface: networkMock,
 			stateMachine:     sm,
 			config:           config,
-			ip:               ip,
+			endpoint:         ip,
 		}
 
 		doneChan := make(chan bool)
@@ -143,7 +143,7 @@ func TestStartARPEnsure(t *testing.T) {
 			networkInterface: networkMock,
 			stateMachine:     sm,
 			config:           config,
-			ip:               ip,
+			endpoint:         ip,
 		}
 
 		doneChan := make(chan bool)

--- a/locker/etcd_locker.go
+++ b/locker/etcd_locker.go
@@ -26,20 +26,20 @@ type etcdLocker struct {
 	kvEtcd            clientv3.KV
 	key               string
 	config            config.Config
-	ip                models.IP
+	ip                models.Endpoint
 	leaseManager      EtcdLeaseManager
 	leaseSubscriberID string
 	lock              *sync.Mutex
 }
 
 // NewEtcdLocker return an implemtation of Locker based on the ETCD database
-func NewEtcdLocker(config config.Config, etcd *clientv3.Client, leaseManager EtcdLeaseManager, ip models.IP) Locker {
-	key := fmt.Sprintf("%s/default/%s", models.EtcdLinkDirectory, ip.StorableIP())
+func NewEtcdLocker(config config.Config, etcd *clientv3.Client, leaseManager EtcdLeaseManager, endpoint models.Endpoint) Locker {
+	key := fmt.Sprintf("%s/default/%s", models.EtcdLinkDirectory, endpoint.StorableIP())
 	return &etcdLocker{
 		kvEtcd:       etcd,
 		key:          key,
 		config:       config,
-		ip:           ip,
+		ip:           endpoint,
 		leaseManager: leaseManager,
 		lock:         &sync.Mutex{},
 	}

--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func main() {
 
 	scheduler := scheduler.NewIPScheduler(config, etcd, storage, leaseManager)
 
-	ips, err := storage.GetIPs(ctx)
+	ips, err := storage.GetEndpoints(ctx)
 	if err != nil {
 		log.WithError(err).Error("Fail to list configured IPs")
 		panic(err)

--- a/migrations/etcd_storage_v0.go
+++ b/migrations/etcd_storage_v0.go
@@ -20,8 +20,8 @@ type v0IP struct {
 	LeaseID int64  `json:"lease_id,omitempty"`
 }
 
-func (v0IP v0IP) convertToV1() models.IP {
-	return models.IP{
+func (v0IP v0IP) convertToV1() models.Endpoint {
+	return models.Endpoint{
 		ID: v0IP.ID,
 		IP: v0IP.IP,
 	}
@@ -80,7 +80,7 @@ func (e v0EtcdStorage) isMaster(ctx context.Context, ip v0IP) (bool, error) {
 }
 
 // putIP puts the v1 IP in the new etcd key.
-func (e v0EtcdStorage) putIP(ctx context.Context, ip models.IP, hostname string) error {
+func (e v0EtcdStorage) putIP(ctx context.Context, ip models.Endpoint, hostname string) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 

--- a/migrations/v0_to_v1.go
+++ b/migrations/v0_to_v1.go
@@ -97,7 +97,7 @@ func (m V0toV1) Migrate(ctx context.Context) error {
 		}
 
 		// We link again the IP with the current host to trigger the topology change in the IP manager
-		err = m.storage.LinkIPWithCurrentHost(ctx, ipV1)
+		err = m.storage.LinkEndpointWithCurrentHost(ctx, ipV1)
 		if err != nil {
 			log.WithError(err).Error("Fail to link IP with the current host during the migration from v0 to v1")
 			continue

--- a/mocks_sig.json
+++ b/mocks_sig.json
@@ -1,14 +1,14 @@
 {
-  "github.com/Scalingo/link/api.Client": "43 2c 65 f4 39 1d 94 6e 27 5d e0 d6 16 f1 42 4b 58 31 f3 0a",
+  "github.com/Scalingo/link/api.Client": "39 c0 14 3b 26 2f 0e f0 c2 bf ed 15 8c 3f 7e e5 28 d7 27 df",
   "github.com/Scalingo/link/healthcheck.Checker": "68 49 fe 4d a3 bb 44 44 63 fd 68 46 63 a1 ac c4 f9 5b 51 3e",
   "github.com/Scalingo/link/locker.EtcdLeaseManager": "ac 51 8b 50 0f d3 c1 d5 76 33 64 4c 3b 57 13 a9 08 f0 58 91",
   "github.com/Scalingo/link/locker.Locker": "a5 24 96 0f 1b f5 df b8 d8 dd 15 83 a1 d2 b2 d3 53 fa 25 0d",
-  "github.com/Scalingo/link/models.Storage": "03 2a 32 33 82 6b 68 dd 02 eb 94 ea 73 b0 a6 d2 e5 68 d6 6e",
+  "github.com/Scalingo/link/models.Storage": "5d 58 75 d4 27 26 25 c7 69 d4 1a 8a f9 dc 38 0c 97 47 62 3d",
   "github.com/Scalingo/link/network.ARP": "20 bb b8 da 57 d8 84 21 24 36 cc 40 34 be f6 c3 e6 e9 f9 78",
   "github.com/Scalingo/link/network.NetworkInterface": "02 61 47 58 85 b3 ce f2 ee 69 f8 58 4b ca cd eb 5b ed f9 3c",
-  "github.com/Scalingo/link/scheduler.Scheduler": "2f 03 7b a9 8a 8c 66 79 58 89 e9 e3 5a ba 27 1e 21 b3 20 18",
+  "github.com/Scalingo/link/scheduler.Scheduler": "6d c9 01 1d 2e d4 8f ae e4 a2 6d d1 04 a7 ae 25 11 8b 36 cb",
   "github.com/Scalingo/link/watcher.Watcher": "22 fd 8e 1a 88 fd 2f 56 0b 5b 14 19 e4 49 cb d7 12 3a 6a 95",
   "go.etcd.io/etcd/client/v3.KV": "b5 dc 10 4e dc 95 f2 cf 0a 6c e7 c5 ac 0a 47 5f 60 44 31 40",
-  "go.etcd.io/etcd/client/v3.Lease": "b7 2a f2 e7 67 c0 af ae 3e 99 7a d8 f0 b6 0f 6c 94 a1 7d 37",
+  "go.etcd.io/etcd/client/v3.Lease": "78 b5 23 7b 09 60 b0 41 9c d1 84 04 80 c2 3f 69 d3 96 5f 8c",
   "go.etcd.io/etcd/client/v3.Txn": "2b d8 86 0c 62 87 e9 d4 e5 71 78 81 ef 89 ec 5a e8 30 43 e1"
 }

--- a/models/healthcheck.go
+++ b/models/healthcheck.go
@@ -3,20 +3,50 @@ package models
 import (
 	"net"
 	"strconv"
+
+	"github.com/Scalingo/link/v2/api"
 )
 
-type HealthcheckType string
+type HealthChecks []HealthCheck
 
-const (
-	TCPHealthCheck HealthcheckType = "TCP"
-)
-
-type Healthcheck struct {
-	Type HealthcheckType `json:"type"`
-	Host string          `json:"host"`
-	Port int             `json:"port"`
+func (h HealthChecks) ToAPIType() []api.HealthCheck {
+	checks := make([]api.HealthCheck, 0, len(h))
+	for _, check := range h {
+		checks = append(checks, check.ToAPIType())
+	}
+	return checks
 }
 
-func (h Healthcheck) Addr() string {
+type HealthCheck struct {
+	Type api.HealthCheckType `json:"type"`
+	Host string              `json:"host"`
+	Port int                 `json:"port"`
+}
+
+func (h HealthCheck) Addr() string {
 	return net.JoinHostPort(h.Host, strconv.Itoa(h.Port))
+}
+
+func (h HealthCheck) ToAPIType() api.HealthCheck {
+	return api.HealthCheck{
+		Type: h.Type,
+		Host: h.Host,
+		Port: h.Port,
+	}
+}
+
+func HealthCheckFromAPIType(h api.HealthCheck) HealthCheck {
+	return HealthCheck{
+		Type: h.Type,
+		Host: h.Host,
+		Port: h.Port,
+	}
+}
+
+func HealthChecksFromAPIType(hs []api.HealthCheck) HealthChecks {
+	checks := make(HealthChecks, 0, len(hs))
+	for _, check := range hs {
+		checks = append(checks, HealthCheckFromAPIType(check))
+	}
+	return checks
 }

--- a/models/ip.go
+++ b/models/ip.go
@@ -5,19 +5,24 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/Scalingo/link/v2/api"
 )
 
-// IP stores the configuration of a virtual IP for one host
-type IP struct {
-	ID                  string        `json:"id"`                   // ID of this Virtual IP (strarting with vip-)
-	IP                  string        `json:"ip"`                   // Full IP with mask (i.e. 10.0.0.1/32)
-	Status              string        `json:"status,omitempty"`     // Status of this VIP
-	Checks              []Healthcheck `json:"checks,omitempty"`     // Healthcheck configured with this VIP
-	HealthcheckInterval int           `json:"healthcheck_interval"` // HealthcheckIntevals for this VIP
+// Endpoint stores the configuration of a virtual IP for one host
+type Endpoint struct {
+	ID string `json:"id"` // ID of this Virtual IP (strarting with vip-)
+
+	// Full IP with mask (i.e. 10.0.0.1/32)
+	IP string `json:"ip"`
+
+	Status              string       `json:"status,omitempty"`     // Status of this VIP
+	Checks              HealthChecks `json:"checks,omitempty"`     // Healthcheck configured with this VIP
+	HealthCheckInterval int          `json:"healthcheck_interval"` // HealthcheckIntevals for this VIP
 }
 
 // ToLogrusFields returns a Logrus representation of an IP
-func (i IP) ToLogrusFields() logrus.Fields {
+func (i Endpoint) ToLogrusFields() logrus.Fields {
 	return logrus.Fields{
 		"ip":    i.IP,
 		"ip_id": i.ID,
@@ -25,8 +30,28 @@ func (i IP) ToLogrusFields() logrus.Fields {
 }
 
 // StorableIP transforms the IP to a string that is compatible with ETCD key naming rules
-func (i IP) StorableIP() string {
+func (i Endpoint) StorableIP() string {
 	return strings.Replace(i.IP, "/", "_", -1)
+}
+
+func (i Endpoint) ToAPIType() api.Endpoint {
+	return api.Endpoint{
+		ID:                  i.ID,
+		IP:                  i.IP,
+		Status:              i.Status,
+		Checks:              i.Checks.ToAPIType(),
+		HealthCheckInterval: i.HealthCheckInterval,
+	}
+}
+
+type Endpoints []Endpoint
+
+func (e Endpoints) ToAPIType() []api.Endpoint {
+	endpoints := make([]api.Endpoint, 0, len(e))
+	for _, endpoint := range e {
+		endpoints = append(endpoints, endpoint.ToAPIType())
+	}
+	return endpoints
 }
 
 // IPLink is the structure stored when an IP is linked to an Host

--- a/models/modelsmock/storage_mock.go
+++ b/models/modelsmock/storage_mock.go
@@ -8,9 +8,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
 	models "github.com/Scalingo/link/v2/models"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockStorage is a mock of Storage interface.
@@ -36,19 +35,19 @@ func (m *MockStorage) EXPECT() *MockStorageMockRecorder {
 	return m.recorder
 }
 
-// AddIP mocks base method.
-func (m *MockStorage) AddIP(arg0 context.Context, arg1 models.IP) (models.IP, error) {
+// AddEndpoint mocks base method.
+func (m *MockStorage) AddEndpoint(arg0 context.Context, arg1 models.Endpoint) (models.Endpoint, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddIP", arg0, arg1)
-	ret0, _ := ret[0].(models.IP)
+	ret := m.ctrl.Call(m, "AddEndpoint", arg0, arg1)
+	ret0, _ := ret[0].(models.Endpoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// AddIP indicates an expected call of AddIP.
-func (mr *MockStorageMockRecorder) AddIP(arg0, arg1 interface{}) *gomock.Call {
+// AddEndpoint indicates an expected call of AddEndpoint.
+func (mr *MockStorageMockRecorder) AddEndpoint(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddIP", reflect.TypeOf((*MockStorage)(nil).AddIP), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEndpoint", reflect.TypeOf((*MockStorage)(nil).AddEndpoint), arg0, arg1)
 }
 
 // GetCurrentHost mocks base method.
@@ -66,62 +65,62 @@ func (mr *MockStorageMockRecorder) GetCurrentHost(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentHost", reflect.TypeOf((*MockStorage)(nil).GetCurrentHost), arg0)
 }
 
-// GetIPHosts mocks base method.
-func (m *MockStorage) GetIPHosts(arg0 context.Context, arg1 models.IP) ([]string, error) {
+// GetEndpointHosts mocks base method.
+func (m *MockStorage) GetEndpointHosts(arg0 context.Context, arg1 models.Endpoint) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIPHosts", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetEndpointHosts", arg0, arg1)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetIPHosts indicates an expected call of GetIPHosts.
-func (mr *MockStorageMockRecorder) GetIPHosts(arg0, arg1 interface{}) *gomock.Call {
+// GetEndpointHosts indicates an expected call of GetEndpointHosts.
+func (mr *MockStorageMockRecorder) GetEndpointHosts(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPHosts", reflect.TypeOf((*MockStorage)(nil).GetIPHosts), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEndpointHosts", reflect.TypeOf((*MockStorage)(nil).GetEndpointHosts), arg0, arg1)
 }
 
-// GetIPs mocks base method.
-func (m *MockStorage) GetIPs(arg0 context.Context) ([]models.IP, error) {
+// GetEndpoints mocks base method.
+func (m *MockStorage) GetEndpoints(arg0 context.Context) (models.Endpoints, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIPs", arg0)
-	ret0, _ := ret[0].([]models.IP)
+	ret := m.ctrl.Call(m, "GetEndpoints", arg0)
+	ret0, _ := ret[0].(models.Endpoints)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetIPs indicates an expected call of GetIPs.
-func (mr *MockStorageMockRecorder) GetIPs(arg0 interface{}) *gomock.Call {
+// GetEndpoints indicates an expected call of GetEndpoints.
+func (mr *MockStorageMockRecorder) GetEndpoints(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPs", reflect.TypeOf((*MockStorage)(nil).GetIPs), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEndpoints", reflect.TypeOf((*MockStorage)(nil).GetEndpoints), arg0)
 }
 
-// LinkIPWithCurrentHost mocks base method.
-func (m *MockStorage) LinkIPWithCurrentHost(arg0 context.Context, arg1 models.IP) error {
+// LinkEndpointWithCurrentHost mocks base method.
+func (m *MockStorage) LinkEndpointWithCurrentHost(arg0 context.Context, arg1 models.Endpoint) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LinkIPWithCurrentHost", arg0, arg1)
+	ret := m.ctrl.Call(m, "LinkEndpointWithCurrentHost", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// LinkIPWithCurrentHost indicates an expected call of LinkIPWithCurrentHost.
-func (mr *MockStorageMockRecorder) LinkIPWithCurrentHost(arg0, arg1 interface{}) *gomock.Call {
+// LinkEndpointWithCurrentHost indicates an expected call of LinkEndpointWithCurrentHost.
+func (mr *MockStorageMockRecorder) LinkEndpointWithCurrentHost(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkIPWithCurrentHost", reflect.TypeOf((*MockStorage)(nil).LinkIPWithCurrentHost), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkEndpointWithCurrentHost", reflect.TypeOf((*MockStorage)(nil).LinkEndpointWithCurrentHost), arg0, arg1)
 }
 
-// RemoveIP mocks base method.
-func (m *MockStorage) RemoveIP(arg0 context.Context, arg1 string) error {
+// RemoveEndpoint mocks base method.
+func (m *MockStorage) RemoveEndpoint(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveIP", arg0, arg1)
+	ret := m.ctrl.Call(m, "RemoveEndpoint", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RemoveIP indicates an expected call of RemoveIP.
-func (mr *MockStorageMockRecorder) RemoveIP(arg0, arg1 interface{}) *gomock.Call {
+// RemoveEndpoint indicates an expected call of RemoveEndpoint.
+func (mr *MockStorageMockRecorder) RemoveEndpoint(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveIP", reflect.TypeOf((*MockStorage)(nil).RemoveIP), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveEndpoint", reflect.TypeOf((*MockStorage)(nil).RemoveEndpoint), arg0, arg1)
 }
 
 // SaveHost mocks base method.
@@ -138,30 +137,30 @@ func (mr *MockStorageMockRecorder) SaveHost(arg0, arg1 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveHost", reflect.TypeOf((*MockStorage)(nil).SaveHost), arg0, arg1)
 }
 
-// UnlinkIPFromCurrentHost mocks base method.
-func (m *MockStorage) UnlinkIPFromCurrentHost(arg0 context.Context, arg1 models.IP) error {
+// UnlinkEndpointFromCurrentHost mocks base method.
+func (m *MockStorage) UnlinkEndpointFromCurrentHost(arg0 context.Context, arg1 models.Endpoint) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnlinkIPFromCurrentHost", arg0, arg1)
+	ret := m.ctrl.Call(m, "UnlinkEndpointFromCurrentHost", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UnlinkIPFromCurrentHost indicates an expected call of UnlinkIPFromCurrentHost.
-func (mr *MockStorageMockRecorder) UnlinkIPFromCurrentHost(arg0, arg1 interface{}) *gomock.Call {
+// UnlinkEndpointFromCurrentHost indicates an expected call of UnlinkEndpointFromCurrentHost.
+func (mr *MockStorageMockRecorder) UnlinkEndpointFromCurrentHost(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkIPFromCurrentHost", reflect.TypeOf((*MockStorage)(nil).UnlinkIPFromCurrentHost), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkEndpointFromCurrentHost", reflect.TypeOf((*MockStorage)(nil).UnlinkEndpointFromCurrentHost), arg0, arg1)
 }
 
-// UpdateIP mocks base method.
-func (m *MockStorage) UpdateIP(arg0 context.Context, arg1 models.IP) error {
+// UpdateEndpoint mocks base method.
+func (m *MockStorage) UpdateEndpoint(arg0 context.Context, arg1 models.Endpoint) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateIP", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateEndpoint", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateIP indicates an expected call of UpdateIP.
-func (mr *MockStorageMockRecorder) UpdateIP(arg0, arg1 interface{}) *gomock.Call {
+// UpdateEndpoint indicates an expected call of UpdateEndpoint.
+func (mr *MockStorageMockRecorder) UpdateEndpoint(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIP", reflect.TypeOf((*MockStorage)(nil).UpdateIP), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEndpoint", reflect.TypeOf((*MockStorage)(nil).UpdateEndpoint), arg0, arg1)
 }

--- a/models/storage.go
+++ b/models/storage.go
@@ -4,15 +4,15 @@ import "context"
 
 // Storage engine needed for the LinK persistent memory
 type Storage interface {
-	GetIPs(context.Context) ([]IP, error) // GetIPs configured for this host
-	AddIP(context.Context, IP) (IP, error)
-	UpdateIP(ctx context.Context, ip IP) error
-	RemoveIP(context.Context, string) error
+	GetEndpoints(context.Context) (Endpoints, error) // GetEndpoints configured for this host
+	AddEndpoint(context.Context, Endpoint) (Endpoint, error)
+	UpdateEndpoint(ctx context.Context, ip Endpoint) error
+	RemoveEndpoint(context.Context, string) error
 
 	GetCurrentHost(context.Context) (Host, error) // Get host configuration for the current host
 	SaveHost(context.Context, Host) error         // Save host modifications
 
-	LinkIPWithCurrentHost(context.Context, IP) error   // Link an IP to the current host
-	UnlinkIPFromCurrentHost(context.Context, IP) error // Unlink an IP from the current host
-	GetIPHosts(context.Context, IP) ([]string, error)  // List all hosts linked to the IP
+	LinkEndpointWithCurrentHost(context.Context, Endpoint) error   // Link an Endpoint to the current host
+	UnlinkEndpointFromCurrentHost(context.Context, Endpoint) error // Unlink an Endpoint from the current host
+	GetEndpointHosts(context.Context, Endpoint) ([]string, error)  // List all hosts linked to the Endpoint
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -8,7 +8,6 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/Scalingo/go-utils/logger"
-	"github.com/Scalingo/link/v2/api"
 	"github.com/Scalingo/link/v2/config"
 	"github.com/Scalingo/link/v2/ip"
 	"github.com/Scalingo/link/v2/locker"
@@ -26,13 +25,13 @@ var (
 // Scheduler is the central point of LinK it will keep track all of IPs registered on this node
 // however the heavy lifting for a single IP is done in the Manager
 type Scheduler interface {
-	Start(context.Context, models.IP) (models.IP, error)
+	Start(context.Context, models.Endpoint) (models.Endpoint, error)
 	Stop(ctx context.Context, id string) error
 	Failover(ctx context.Context, id string) error
 	Status(string) string
-	ConfiguredIPs(ctx context.Context) []api.IP
-	GetIP(ctx context.Context, id string) *api.IP
-	UpdateIP(context.Context, models.IP) error
+	ConfiguredEndpoints(ctx context.Context) EndpointsWithStatus
+	GetEndpoint(ctx context.Context, id string) *EndpointWithStatus
+	UpdateEndpoint(context.Context, models.Endpoint) error
 }
 
 // IPScheduler is LinK implementation of the Scheduler Interface
@@ -69,13 +68,13 @@ func (s *IPScheduler) Status(id string) string {
 }
 
 // Start schedules a new IP on the host. It launches a new manager for the IP and add it to the tracked IP on this host.
-func (s *IPScheduler) Start(ctx context.Context, ipAddr models.IP) (models.IP, error) {
+func (s *IPScheduler) Start(ctx context.Context, endpoint models.Endpoint) (models.Endpoint, error) {
 	log := logger.Get(ctx)
-	newIP, err := s.storage.AddIP(ctx, ipAddr)
+	newIP, err := s.storage.AddEndpoint(ctx, endpoint)
 	if err != nil {
 		if errors.Cause(err) != models.ErrIPAlreadyPresent {
 			return newIP, errors.Wrap(err, "fail to add IP to storage")
-		} else if ipAddr.ID == "" { // If the ID is not empty we are in the startup process
+		} else if endpoint.ID == "" { // If the ID is not empty we are in the startup process
 			return newIP, ErrIPAlreadyAssigned
 		}
 	}
@@ -88,7 +87,7 @@ func (s *IPScheduler) Start(ctx context.Context, ipAddr models.IP) (models.IP, e
 	manager, err := ip.NewManager(ctx, s.config, newIP, s.etcd, s.storage, s.leaseManager)
 	if err != nil {
 		if ipAdded {
-			err := s.storage.RemoveIP(ctx, newIP.ID)
+			err := s.storage.RemoveEndpoint(ctx, newIP.ID)
 			if err != nil {
 				log.WithError(err).Error("Fail to remove IP from storage after failed initialization of IP manager")
 			}
@@ -118,7 +117,7 @@ func (s *IPScheduler) Stop(ctx context.Context, id string) error {
 		return errors.Wrap(err, "fail to stop manager")
 	}
 
-	err = s.storage.RemoveIP(ctx, id)
+	err = s.storage.RemoveEndpoint(ctx, id)
 	if err != nil {
 		return errors.Wrap(err, "fail to remove IP from storage")
 	}
@@ -147,22 +146,23 @@ func (s *IPScheduler) Failover(ctx context.Context, id string) error {
 }
 
 // ConfiguredIPs lists all IPs currently tracked by the scheduler
-func (s *IPScheduler) ConfiguredIPs(ctx context.Context) []api.IP {
+func (s *IPScheduler) ConfiguredEndpoints(ctx context.Context) EndpointsWithStatus {
 	s.mapMutex.RLock()
 	defer s.mapMutex.RUnlock()
 
-	var ips []api.IP
+	res := make(EndpointsWithStatus, 0, len(s.ipManagers))
+
 	for _, manager := range s.ipManagers {
-		ips = append(ips, api.IP{
-			IP:     manager.IP(),
-			Status: manager.Status(),
+		res = append(res, EndpointWithStatus{
+			Endpoint: manager.Endpoint(),
+			Status:   manager.Status(),
 		})
 	}
-	return ips
+	return res
 }
 
 // GetIP fetches basic information about a tracked IP
-func (s *IPScheduler) GetIP(ctx context.Context, id string) *api.IP {
+func (s *IPScheduler) GetEndpoint(ctx context.Context, id string) *EndpointWithStatus {
 	s.mapMutex.RLock()
 	defer s.mapMutex.RUnlock()
 
@@ -170,29 +170,30 @@ func (s *IPScheduler) GetIP(ctx context.Context, id string) *api.IP {
 	if !ok {
 		return nil
 	}
-	return &api.IP{
-		IP:     manager.IP(),
-		Status: manager.Status(),
+
+	return &EndpointWithStatus{
+		Endpoint: manager.Endpoint(),
+		Status:   manager.Status(),
 	}
 }
 
 // UpdateIP updates the IP in the scheduler storage, and the healthchecks in the IP manager.
-func (s *IPScheduler) UpdateIP(ctx context.Context, ip models.IP) error {
+func (s *IPScheduler) UpdateEndpoint(ctx context.Context, endpoint models.Endpoint) error {
 	log := logger.Get(ctx)
 	s.mapMutex.RLock()
-	manager, ok := s.ipManagers[ip.ID]
+	manager, ok := s.ipManagers[endpoint.ID]
 	s.mapMutex.RUnlock()
 	if !ok {
 		log.Info("IP manager not found, skipping the IP update")
 		return nil
 	}
 
-	err := s.storage.UpdateIP(ctx, ip)
+	err := s.storage.UpdateEndpoint(ctx, endpoint)
 	if err != nil {
 		return errors.Wrap(err, "fail to update the IP from storage")
 	}
 
-	manager.SetHealthchecks(ctx, s.config, ip.Checks)
+	manager.SetHealthChecks(ctx, s.config, endpoint.Checks)
 
 	return nil
 }

--- a/scheduler/schedulermock/scheduler_mock.go
+++ b/scheduler/schedulermock/scheduler_mock.go
@@ -8,10 +8,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-
-	api "github.com/Scalingo/link/v2/api"
 	models "github.com/Scalingo/link/v2/models"
+	scheduler "github.com/Scalingo/link/v2/scheduler"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockScheduler is a mock of Scheduler interface.
@@ -37,18 +36,18 @@ func (m *MockScheduler) EXPECT() *MockSchedulerMockRecorder {
 	return m.recorder
 }
 
-// ConfiguredIPs mocks base method.
-func (m *MockScheduler) ConfiguredIPs(arg0 context.Context) []api.IP {
+// ConfiguredEndpoints mocks base method.
+func (m *MockScheduler) ConfiguredEndpoints(arg0 context.Context) scheduler.EndpointsWithStatus {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfiguredIPs", arg0)
-	ret0, _ := ret[0].([]api.IP)
+	ret := m.ctrl.Call(m, "ConfiguredEndpoints", arg0)
+	ret0, _ := ret[0].(scheduler.EndpointsWithStatus)
 	return ret0
 }
 
-// ConfiguredIPs indicates an expected call of ConfiguredIPs.
-func (mr *MockSchedulerMockRecorder) ConfiguredIPs(arg0 interface{}) *gomock.Call {
+// ConfiguredEndpoints indicates an expected call of ConfiguredEndpoints.
+func (mr *MockSchedulerMockRecorder) ConfiguredEndpoints(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfiguredIPs", reflect.TypeOf((*MockScheduler)(nil).ConfiguredIPs), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfiguredEndpoints", reflect.TypeOf((*MockScheduler)(nil).ConfiguredEndpoints), arg0)
 }
 
 // Failover mocks base method.
@@ -65,25 +64,25 @@ func (mr *MockSchedulerMockRecorder) Failover(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Failover", reflect.TypeOf((*MockScheduler)(nil).Failover), arg0, arg1)
 }
 
-// GetIP mocks base method.
-func (m *MockScheduler) GetIP(arg0 context.Context, arg1 string) *api.IP {
+// GetEndpoint mocks base method.
+func (m *MockScheduler) GetEndpoint(arg0 context.Context, arg1 string) *scheduler.EndpointWithStatus {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIP", arg0, arg1)
-	ret0, _ := ret[0].(*api.IP)
+	ret := m.ctrl.Call(m, "GetEndpoint", arg0, arg1)
+	ret0, _ := ret[0].(*scheduler.EndpointWithStatus)
 	return ret0
 }
 
-// GetIP indicates an expected call of GetIP.
-func (mr *MockSchedulerMockRecorder) GetIP(arg0, arg1 interface{}) *gomock.Call {
+// GetEndpoint indicates an expected call of GetEndpoint.
+func (mr *MockSchedulerMockRecorder) GetEndpoint(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIP", reflect.TypeOf((*MockScheduler)(nil).GetIP), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEndpoint", reflect.TypeOf((*MockScheduler)(nil).GetEndpoint), arg0, arg1)
 }
 
 // Start mocks base method.
-func (m *MockScheduler) Start(arg0 context.Context, arg1 models.IP) (models.IP, error) {
+func (m *MockScheduler) Start(arg0 context.Context, arg1 models.Endpoint) (models.Endpoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", arg0, arg1)
-	ret0, _ := ret[0].(models.IP)
+	ret0, _ := ret[0].(models.Endpoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -122,16 +121,16 @@ func (mr *MockSchedulerMockRecorder) Stop(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockScheduler)(nil).Stop), arg0, arg1)
 }
 
-// UpdateIP mocks base method.
-func (m *MockScheduler) UpdateIP(arg0 context.Context, arg1 models.IP) error {
+// UpdateEndpoint mocks base method.
+func (m *MockScheduler) UpdateEndpoint(arg0 context.Context, arg1 models.Endpoint) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateIP", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateEndpoint", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateIP indicates an expected call of UpdateIP.
-func (mr *MockSchedulerMockRecorder) UpdateIP(arg0, arg1 interface{}) *gomock.Call {
+// UpdateEndpoint indicates an expected call of UpdateEndpoint.
+func (mr *MockSchedulerMockRecorder) UpdateEndpoint(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateIP", reflect.TypeOf((*MockScheduler)(nil).UpdateIP), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEndpoint", reflect.TypeOf((*MockScheduler)(nil).UpdateEndpoint), arg0, arg1)
 }

--- a/scheduler/types.go
+++ b/scheduler/types.go
@@ -1,0 +1,28 @@
+package scheduler
+
+import (
+	"github.com/Scalingo/link/v2/api"
+	"github.com/Scalingo/link/v2/models"
+)
+
+type EndpointWithStatus struct {
+	models.Endpoint
+
+	Status string
+}
+
+func (e EndpointWithStatus) ToAPIType() api.Endpoint {
+	res := e.Endpoint.ToAPIType()
+	res.Status = e.Status
+	return res
+}
+
+type EndpointsWithStatus []EndpointWithStatus
+
+func (e EndpointsWithStatus) ToAPIType() []api.Endpoint {
+	res := make([]api.Endpoint, len(e))
+	for i, ep := range e {
+		res[i] = ep.ToAPIType()
+	}
+	return res
+}


### PR DESCRIPTION
Related to STORY-1595

This PR doesn't change anything in the current LinK APIs nor functionalities. It's a simple refactoring to help put in place the base infrastructure needed for the plugin architecture.

The only change with the current version is that the `PATCH` response JSON now contains the Endpoint status where it did not in the previous versions.