### PR TITLE
fix(broken_import) Rollback to go-utils/logger@v1.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Scalingo/go-utils/errors v1.1.1
 	github.com/Scalingo/go-utils/errors/v2 v2.5.0
 	github.com/Scalingo/go-utils/etcd v1.2.0
-	github.com/Scalingo/go-utils/logger v1.9.0
+	github.com/Scalingo/go-utils/logger v1.6.0
 	github.com/Scalingo/go-utils/retry v1.2.0
 	github.com/gofrs/uuid/v5 v5.3.2
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/Scalingo/go-utils/errors/v2 v2.5.0 h1:aBQF3st7gBS9UbXa8RxkhO1qZb+6e/Z
 github.com/Scalingo/go-utils/errors/v2 v2.5.0/go.mod h1:aY5TjRfIlqlsKTJGpxuk7AnporNVjn0LdcquXenLwjg=
 github.com/Scalingo/go-utils/etcd v1.2.0 h1:Enu7cvRY7kpDSTGT2xQtCG5wyemAKT5Forlb+lwuHuM=
 github.com/Scalingo/go-utils/etcd v1.2.0/go.mod h1:sCyoCLfZyWolLTPb+p18SQcCgXgpAWV1KVmHfXKmEc8=
-github.com/Scalingo/go-utils/logger v1.9.0 h1:djr3YaA7LourAjsZmkgQebtMHQLnHwJz8M1vj9+/8R4=
-github.com/Scalingo/go-utils/logger v1.9.0/go.mod h1:2wzJAC2aOGzpEtKs+PcWhecSe/wVJua8wguDajbk0j0=
+github.com/Scalingo/go-utils/logger v1.6.0 h1:YyorhN7NNN0zsIYFtfgfY0pTSPek2pgppX500O0I7H8=
+github.com/Scalingo/go-utils/logger v1.6.0/go.mod h1:2wzJAC2aOGzpEtKs+PcWhecSe/wVJua8wguDajbk0j0=
 github.com/Scalingo/go-utils/retry v1.2.0 h1:Moc8eSKOWF59FUEkNl8wyRksXLkEFH8W/QC4SgCm2Ek=
 github.com/Scalingo/go-utils/retry v1.2.0/go.mod h1:YFGDWS6CUfgHwIJJ54istrtkxNuw3Ug1CTXYtZVq2ic=
 github.com/Scalingo/go-utils/security v1.1.0 h1:+YdMYJTMX2DfEdBm71QC2y3ETQw/HOIBPgJf9IGogrw=

--- a/vendor/github.com/Scalingo/go-utils/logger/CHANGELOG.md
+++ b/vendor/github.com/Scalingo/go-utils/logger/CHANGELOG.md
@@ -2,18 +2,6 @@
 
 ## To be Released
 
-## v1.9.0
-
-* chore(go): upgrade to Go 1.24
-
-## v1.8.0
-
-* chore(go): upgrade to Go 1.24
-
-## v1.7.0
-
-* chore(go): upgrade to Go 1.24
-
 ## v1.6.0
 
 * chore(go): upgrade to Go 1.24

--- a/vendor/github.com/Scalingo/go-utils/logger/README.md
+++ b/vendor/github.com/Scalingo/go-utils/logger/README.md
@@ -1,4 +1,4 @@
-# Package `logger` v1.9.0
+# Package `logger` v1.6.0
 
 This package will provide you a generic way to handle logging.
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -21,7 +21,7 @@ github.com/Scalingo/go-utils/errors/v2
 # github.com/Scalingo/go-utils/etcd v1.2.0
 ## explicit; go 1.24.3
 github.com/Scalingo/go-utils/etcd
-# github.com/Scalingo/go-utils/logger v1.9.0
+# github.com/Scalingo/go-utils/logger v1.6.0
 ## explicit; go 1.24.3
 github.com/Scalingo/go-utils/logger
 github.com/Scalingo/go-utils/logger/plugins/rollbarplugin


### PR DESCRIPTION
The 1.9.0 release was a mistake and has been pruned from the repo