### PR TITLE
test(integration): more flakky tests are failing...

### DIFF
--- a/tests/integration/v2_to_v3_test.go
+++ b/tests/integration/v2_to_v3_test.go
@@ -1,4 +1,4 @@
-package upgrades
+package integration
 
 import (
 	"slices"
@@ -27,6 +27,7 @@ func Test_UpdateFromV2ToV3(t *testing.T) {
 
 		expectedIP, err := v2client.AddIP(t.Context(), "10.20.0.1/32", v2api.AddIPParams{})
 		require.NoError(t, err)
+
 		ips, err := v2client.ListIPs(t.Context())
 		require.NoError(t, err)
 		containsIP := slices.ContainsFunc(ips, func(ip v2api.IP) bool {


### PR DESCRIPTION
Despite PR #321, I identified more tests which randomly fail. This is an attempt to fix all these tests, even though it's hard to make sure as by definition, they fail only from time to time.

I executed the tests 10 times, and they no longer fail. Hence I hope we fixed all random tests.

One thing I had to change is to move all integration tests in a single package so that they are not executed in parallel. From the [`go test` man page](https://manpages.debian.org/testing/golang-go/go-testflag.7.en.html):

> The ‘go test’ command may run tests for different packages in parallel as well

Hence Go tests in different packages may be executed in parallel. In the integration tests, it led to an issue: at the beginning of each integration tests, we remove all LinK related data from etcd. If tests in packages `tests/integration/secrets` and `tests/integration/upgrades` are executed concurrently, etcd data from test in `tests/integration/secrets` may be removed by the execution of tests in `tests/integration/upgrades`.

I tried to find another solution with no success. I don't want to spend more time on this. Removing the parallel execution makes the integration tests succeed.