### PR TITLE
fix(parallelism) Protect the endpointManagers election key protection by a mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## To be released
+## To be release>d
+
+- fix(parallelism) Fix a potential crash when starting a new endpoint
 
 ## [2025-12-30] v3.2.1
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -85,11 +85,14 @@ func (s *EndpointScheduler) Start(ctx context.Context, endpoint models.Endpoint)
 
 	ctx, log = logger.WithFieldToCtx(ctx, "election_key", plugin.ElectionKey(ctx))
 
+	s.mapMutex.RLock()
 	for _, manager := range s.endpointManagers {
 		if manager.ElectionKey(ctx) == plugin.ElectionKey(ctx) {
+			s.mapMutex.RUnlock()
 			return endpoint, errors.Wrap(ctx, ErrEndpointAlreadyAssigned, "endpoint already assigned")
 		}
 	}
+	s.mapMutex.RUnlock()
 
 	log.Info("Initialize a new endpoint manager")
 


### PR DESCRIPTION
Fix #330