### PR TITLE
Fix actions/checkout version hash

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           echo "$TAG_NAME"
 
       - name: Checkout the code
-        uses: actions/checkout@v9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Go environment
         uses: actions/setup-go@v6


### PR DESCRIPTION
I made a small mistake in the dependabot PR, it fixes that.