### PR TITLE
fix: make link containers reboot proof on dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
       PORT: 1313
     command: reflex -r '\.go$$' -R '_test\.go$$' -s -- sh -c 'go build -buildvcs=false && ./link'
     depends_on:
-      - etcd
+      etcd:
+        condition: service_healthy
   link-2:
     build: .
     volumes:
@@ -32,7 +33,8 @@ services:
       PORT: 1314
     command: reflex --all -r 'link' -s -- sh -c './link'
     depends_on:
-      - etcd
+      etcd:
+        condition: service_healthy
   link-3:
     build: .
     volumes:
@@ -49,7 +51,8 @@ services:
       PORT: 1315
     command: reflex --all -r 'link' -s -- sh -c './link'
     depends_on:
-      - etcd
+      etcd:
+        condition: service_healthy
   link-4:
     build: .
     volumes:
@@ -66,7 +69,8 @@ services:
       PORT: 1316
     command: reflex --all -r 'link' -s -- sh -c './link'
     depends_on:
-      - etcd
+      etcd:
+        condition: service_healthy
   link-5:
     build: .
     volumes:
@@ -83,7 +87,8 @@ services:
       PORT: 1317
     command: reflex --all -r 'link' -s -- sh -c './link'
     depends_on:
-      - etcd
+      etcd:
+        condition: service_healthy
   link-6:
     build: .
     volumes:
@@ -100,7 +105,8 @@ services:
       PORT: 1318
     command: reflex --all -r 'link' -s -- sh -c './link'
     depends_on:
-      - etcd
+      etcd:
+        condition: service_healthy
 
   test:
     build: .
@@ -121,3 +127,9 @@ services:
     command: etcd --name etcd-cluster --data-dir /data/etcd --listen-client-urls http://0.0.0.0:2379 --listen-peer-urls http://0.0.0.0:2380 --advertise-client-urls http://172.17.0.1:32379
     ports:
       - 32379:2379
+    healthcheck:
+      test: ["CMD", "etcdctl", "--endpoints=http://127.0.0.1:2379", "endpoint", "health"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 10s


### PR DESCRIPTION
On my Dev environment, my `link` containers all fail to start after my computer startup:
```
link-1-1  | [00] ERRO[2026-07-13T08:43:33.404] Fail to run migrations                        error="check if migration v0 to v1 is needed: fail to get current host to check if it needs data migration from v0 to v1: get current host: get host from etcd: context deadline exceeded"
link-1-1  | [00] ERRO[2026-07-13T08:43:33.405] Fail to start lease manager                   error="fail to find host config: get current host: get host from etcd: context deadline exceeded"
link-1-1  | [00] panic: fail to find host config: get current host: get host from etcd: context deadline exceeded
link-1-1  | [00] 
link-1-1  | [00] goroutine 1 [running]:
link-1-1  | [00] main.main()
link-1-1  | [00] 	/go/src/github.com/Scalingo/link/main.go:87 +0x24e7
link-1-1  | [00] (error exit: exit status 2)
```
This was fixed by the service containers restart.

As suggested by IST colleagues, I introduced a healthcheck in my docker compose to enforce the `etcd` is up and running before starting the `link` containers.